### PR TITLE
Safer location update

### DIFF
--- a/Amplitude.h
+++ b/Amplitude.h
@@ -40,4 +40,6 @@
 
 + (void)printEventsCount;
 
++ (void)setUploadDelay:(NSUInteger)seconds;
+
 @end


### PR DESCRIPTION
We had 50 users (very small number, but nonetheless) crash with the following report from Crashlytics:

```
Fatal Exception NSInvalidArgumentException
-[__NSDate coordinate]: unrecognized selector sent to instance 0x1f779f90
0 ...    CoreFoundation  __exceptionPreprocess + 162
1    libobjc.A.dylib     objc_exception_throw + 30
2    CoreFoundation  __methodDescriptionForSelector
3    CoreFoundation  ___forwarding___ + 392
4    CoreFoundation  __forwarding_prep_1___ + 24
5    CoreFoundation  __invoking___ + 68
6    CoreFoundation  -[NSInvocation invoke] + 290
7    Juliet     
Amplitude.m line 508
+[Amplitude addBoilerplate:timestamp:maxIdCheck:]
8    Juliet 
Amplitude.m line 454
__57+[Amplitude logEvent:withCustomProperties:apiProperties:]_block_invoke
9    Foundation  -[NSBlockOperation main] + 200
10   Foundation  -[__NSOperationInternal start] + 840
11   Foundation  __block_global_6 + 102
12 ...   libdispatch.dylib   _dispatch_call_block_and_release + 10
13   libdispatch.dylib   _dispatch_root_queue_drain + 278
14   libdispatch.dylib   _dispatch_worker_thread2 + 92
15   libsystem_c.dylib   _pthread_wqthread + 360
16   libsystem_c.dylib   start_wqthread + 8
```

Looks like the lastKnownLocation is being used after it got deallocated, so I added an events based synchronize on a background operation when updating the location.
