### PR TITLE
create location manager on the main thread

### DIFF
--- a/Amplitude.m
+++ b/Amplitude.m
@@ -182,12 +182,14 @@ static AmplitudeLocationManagerDelegate *locationManagerDelegate;
         [backgroundQueue setSuspended:NO];
     }];
     
-    // Location manager callbacks must be fired on a thread with a run loop (eg the main thread)
-    Class CLLocationManager = NSClassFromString(@"CLLocationManager");
-    locationManager = [[CLLocationManager alloc] init];
-    locationManagerDelegate = [[AmplitudeLocationManagerDelegate alloc] init];
-    SEL setDelegate = NSSelectorFromString(@"setDelegate:");
-    [locationManager performSelector:setDelegate withObject:locationManagerDelegate];
+    // CLLocationManager must be created on the main thread
+    dispatch_async(dispatch_get_main_queue(), ^{
+        Class CLLocationManager = NSClassFromString(@"CLLocationManager");
+        locationManager = [[CLLocationManager alloc] init];
+        locationManagerDelegate = [[AmplitudeLocationManagerDelegate alloc] init];
+        SEL setDelegate = NSSelectorFromString(@"setDelegate:");
+        [locationManager performSelector:setDelegate withObject:locationManagerDelegate];
+    });
 }
 
 + (void)initializeApiKey:(NSString*) apiKey


### PR DESCRIPTION
CLLocationManager doesn't like to be initialized on a queue other than main. Currently Amplitude causes the following output in the system.log

> <Notice>: CoreLocation: A location manager (0xd1623e0) was created on a dispatch queue executing on a thread other than the main thread.  It is the developer's responsibility to ensure that there is a run loop running on the thread on which the location manager object is allocated.  In particular, creating location managers in arbitrary dispatch queues (not attached to the main queue) is not supported and will result in callbacks not being received.

We are trying to debug a hard to reproduce Core Location crash and want to rule out this as an issue. 
