### PR TITLE
Fixing background task bug when app is minimized and maximized quickly a...

### DIFF
--- a/Amplitude.m
+++ b/Amplitude.m
@@ -723,6 +723,10 @@ static AmplitudeLocationManagerDelegate *locationManagerDelegate;
 {
     [Amplitude updateLocation];
     [Amplitude startSession];
+    if (uploadTaskID != UIBackgroundTaskInvalid) {
+        [[UIApplication sharedApplication] endBackgroundTask:uploadTaskID];
+        uploadTaskID = UIBackgroundTaskInvalid;
+    }
     [backgroundQueue addOperationWithBlock:^{
         [Amplitude uploadEvents];
     }];
@@ -730,6 +734,9 @@ static AmplitudeLocationManagerDelegate *locationManagerDelegate;
 
 + (void)enterBackground
 {
+    if (uploadTaskID != UIBackgroundTaskInvalid) {
+        [[UIApplication sharedApplication] endBackgroundTask:uploadTaskID];
+    }
     uploadTaskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         //Took too long, manually stop
         [[UIApplication sharedApplication] endBackgroundTask:uploadTaskID];


### PR DESCRIPTION
... few times causing a dangling task to never be ended.

This makes sure to end the background task on enterForeground and also end any existing background task within enterBackground. I can usually get this problem reproduced by quickly minimizing and maximizing the app a few times and then seeing iOS force close it 180 seconds later.
