### PR TITLE
Fix CLLocationManager authorization constants warn

### DIFF
--- a/Amplitude/AMPLocationManagerDelegate.m
+++ b/Amplitude/AMPLocationManagerDelegate.m
@@ -17,7 +17,11 @@
 
 - (void)locationManager:(CLLocationManager*) manager didChangeAuthorizationStatus:(CLAuthorizationStatus) status
 {
+#ifdef __IPHONE_8_0
+    if (status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse) {
+#else
     if (status == kCLAuthorizationStatusAuthorized) {
+#endif
         SEL updateLocation = NSSelectorFromString(@"updateLocation");
         [Amplitude performSelector:updateLocation];
     }


### PR DESCRIPTION
Updates AMPLocationManagerDelegate.m to use the correct authorization
constants based on definition of `__IPHONE_8_0` in Availability.h.