### PR TITLE
Add logic to disable logging for users that wish to opt out.

### DIFF
--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -43,6 +43,8 @@
 
 #pragma mark - Methods
 
++ (Amplitude *)instance;
+
 - (void)initializeApiKey:(NSString*) apiKey;
 
 - (void)initializeApiKey:(NSString*) apiKey userId:(NSString*) userId;

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -65,6 +65,8 @@
 
 - (void)setUserId:(NSString*) userId;
 
+- (void)setOptOut:(BOOL)enabled;
+
 - (void)enableLocationListening;
 
 - (void)disableLocationListening;

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -67,7 +67,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 #pragma mark - Static methods
 
-+ (id)instance {
++ (Amplitude *)instance {
     static Amplitude *_instance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -502,6 +502,12 @@ AMPLocationManagerDelegate *locationManagerDelegate;
     [_backgroundQueue addOperationWithBlock:^{
         
         @synchronized (_eventsData) {
+            // Don't communicate with the server if the user has opted out.
+            if ([[_eventsData objectForKey:@"opt_out"] boolValue])  {
+                updatingCurrently = NO;
+                return;
+            }
+
             NSMutableArray *events = [_eventsData objectForKey:@"events"];
             long long numEvents = limit ? fminl([events count], limit) : [events count];
             if (numEvents == 0) {

--- a/AmplitudeTests/InitializeTests.m
+++ b/AmplitudeTests/InitializeTests.m
@@ -108,6 +108,22 @@ id partialMock;
     XCTAssert([amplitude initialized]);
 }
 
+- (void)testOptOut {
+    [amplitude initializeApiKey:apiKey];
+
+    [amplitude setOptOut:YES];
+    [amplitude logEvent:@"Opted Out"];
+    [amplitude flushQueue];
+
+    XCTAssert(![[amplitude getLastEvent][@"event_type"] isEqualToString:@"Opted Out"]);
+
+    [amplitude setOptOut:NO];
+    [amplitude logEvent:@"Opted In"];
+    [amplitude flushQueue];
+
+    XCTAssert([[amplitude getLastEvent][@"event_type"] isEqualToString:@"Opted In"]);
+}
+
 - (void)testUserPropertiesSet {
     [amplitude initializeApiKey:apiKey];
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,21 @@ NSMutableDictionary *userProperties = [NSMutableDictionary dictionary];
 [Amplitude setUserProperties:userProperties];
 ```
 
+To replace any existing user properties with a new set:
+
+``` objective-c
+NSMutableDictionary *userProperties = [NSMutableDictionary dictionary];
+[userProperties setValue:@"VALUE_GOES_HERE" forKey:@"KEY_GOES_HERE"];
+[[Amplitude instance] setUserProperties:userProperties replace:YES];
+```
+
+
 # Allowing Users to Opt Out
 
 To stop all event and session logging for a user, call setOptOut:
 
 ``` objective-c
-[Amplitude setOptOut:YES];
+[[Amplitude instance] setOptOut:YES];
 ```
 
 Logging can be restarted by calling setOptOut again with enabled set to NO.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ NSMutableDictionary *userProperties = [NSMutableDictionary dictionary];
 [Amplitude setUserProperties:userProperties];
 ```
 
+# Allowing Users to Opt Out
+
+To stop all event and session logging for a user, call setOptOut:
+
+``` objective-c
+[Amplitude setOptOut:YES];
+```
+
+Logging can be restarted by calling setOptOut again with enabled set to NO.
+No events will be logged during any period opt out is enabled, even after opt
+out is disabled.
+
 # Tracking Revenue #
 
 To track revenue from a user, call


### PR DESCRIPTION
This will allow apps to add a UI for allowing user to opt out of tracking. It also allows users to opt back in. During any period opt out is enabled, all logged events (including revenue and sessions) are ignored and not persisted anywhere.