### PR TITLE
Fix session handling when tracking silent push notifs

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9D82D1D81AC1006600C3F321 /* SetupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D82D1D71AC1006600C3F321 /* SetupTests.m */; };
 		9DFBB9C71AB0D1DD0017F703 /* Amplitude+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFBB9C61AB0D1DD0017F703 /* Amplitude+Test.m */; };
 		9DFBB9CA1AB0D26E0017F703 /* BaseTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFBB9C91AB0D26E0017F703 /* BaseTestCase.m */; };
+		9DFBB9CC1AB0D47A0017F703 /* SessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFBB9CB1AB0D47A0017F703 /* SessionTests.m */; };
 		E93C8C551A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E93C8C541A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m */; };
 		E96785EC1A48E93F00887CCD /* AMPDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E41A48E93F00887CCD /* AMPDeviceInfo.m */; };
 		E96785ED1A48E93F00887CCD /* Amplitude.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E71A48E93F00887CCD /* Amplitude.m */; };
@@ -66,6 +67,7 @@
 		9DFBB9C61AB0D1DD0017F703 /* Amplitude+Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Amplitude+Test.m"; sourceTree = "<group>"; };
 		9DFBB9C81AB0D26E0017F703 /* BaseTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseTestCase.h; sourceTree = "<group>"; };
 		9DFBB9C91AB0D26E0017F703 /* BaseTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BaseTestCase.m; sourceTree = "<group>"; };
+		9DFBB9CB1AB0D47A0017F703 /* SessionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionTests.m; sourceTree = "<group>"; };
 		C671D5C7AB6BB2A4B86F6EDF /* Pods-test.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-test.release.xcconfig"; path = "Pods/Target Support Files/Pods-test/Pods-test.release.xcconfig"; sourceTree = "<group>"; };
 		E93C8C541A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPLocationManagerDelegateTests.m; sourceTree = "<group>"; };
 		E96785E11A48E93F00887CCD /* AMPARCMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPARCMacros.h; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				9DFBB9C81AB0D26E0017F703 /* BaseTestCase.h */,
 				9DFBB9C91AB0D26E0017F703 /* BaseTestCase.m */,
 				9D40E1941AB3F6550095C7C6 /* InvalidCertificationAuthority.der */,
+				9DFBB9CB1AB0D47A0017F703 /* SessionTests.m */,
 				9D82D1D71AC1006600C3F321 /* SetupTests.m */,
 				9D265EF31AB3FA2500399D93 /* SSLPinningTests.m */,
 				E98C05301A48E7FE00800C63 /* Supporting Files */,
@@ -338,6 +341,7 @@
 				9D6E19561ACCDE9000352C6C /* ISPCertificatePinning.m in Sources */,
 				9D6E19571ACCDE9000352C6C /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				9D6E19581ACCDE9000352C6C /* ISPPinnedNSURLSessionDelegate.m in Sources */,
+				9DFBB9CC1AB0D47A0017F703 /* SessionTests.m in Sources */,
 				E96786001A48FBD100887CCD /* AMPDeviceInfo.m in Sources */,
 				9DFBB9CA1AB0D26E0017F703 /* BaseTestCase.m in Sources */,
 				9D82D1D81AC1006600C3F321 /* SetupTests.m in Sources */,

--- a/Amplitude/AMPConstants.m
+++ b/Amplitude/AMPConstants.m
@@ -1,0 +1,18 @@
+//
+//  AMPConstants.m
+
+#import "AMPConstants.h"
+
+NSString *const kAMPLibrary = @"amplitude-ios";
+NSString *const kAMPPlatform = @"iOS";
+NSString *const kAMPVersion = @"2.3.0";
+NSString *const kAMPEventLogDomain = @"api.amplitude.com";
+NSString *const kAMPEventLogUrl = @"https://api.amplitude.com/";
+const int kAMPApiVersion = 2;
+const int kAMPEventUploadThreshold = 30;
+const int kAMPEventUploadMaxBatchSize = 100;
+const int kAMPEventMaxCount = 1000;
+const int kAMPEventRemoveBatchSize = 20;
+const int kAMPEventUploadPeriodSeconds = 30; // 30s
+const long kAMPMinTimeBetweenSessionsMillis = 15 * 1000; // 15s
+const long kAMPSessionTimeoutMillis = 30 * 60 * 1000; // 30m

--- a/Amplitude/AMPDeviceInfo.m
+++ b/Amplitude/AMPDeviceInfo.m
@@ -192,7 +192,7 @@
 #endif
     CFRelease(uuid);
     // Add "R" at the end of the ID to distinguish it from advertiserId
-    NSString *result = [uuidStr stringByAppendingString:@"R"];
+    NSString *result = SAFE_ARC_AUTORELEASE([uuidStr stringByAppendingString:@"R"]);
     SAFE_ARC_RELEASE(uuidStr);
     return result;
 }

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -51,6 +51,8 @@
 
 - (void)initializeApiKey:(NSString*) apiKey userId:(NSString*) userId startSession:(BOOL)startSession;
 
+- (void)startSession;
+
 - (void)logEvent:(NSString*) eventType;
 
 - (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties;

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -49,6 +49,8 @@
 
 - (void)initializeApiKey:(NSString*) apiKey userId:(NSString*) userId;
 
+- (void)initializeApiKey:(NSString*) apiKey userId:(NSString*) userId startSession:(BOOL)startSession;
+
 - (void)logEvent:(NSString*) eventType;
 
 - (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties;

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -228,7 +228,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
         [center addObserver:self
                    selector:@selector(enterForeground)
-                       name:UIApplicationWillEnterForegroundNotification
+                       name:UIApplicationDidBecomeActiveNotification
                      object:nil];
         [center addObserver:self
                    selector:@selector(enterBackground)
@@ -288,11 +288,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         }
     }];
 
-    if (!_initialized) {
-        _initialized = YES;
-
-        [self enterForeground];
-    }
+    _initialized = YES;
 }
 
 #pragma mark - logEvent

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -163,6 +163,8 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         [_backgroundQueue setMaxConcurrentOperationCount:1];
         // Ensure initialize finishes running asynchronously before other calls are run
         [_backgroundQueue setSuspended:YES];
+        // Name the queue so runOnBackgroundQueue can tell which queue an operation is running
+        _backgroundQueue.name = @"BACKGROUND";
         
         [initializerQueue addOperationWithBlock:^{
 
@@ -278,7 +280,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
     SAFE_ARC_RELEASE(_apiKey);
     _apiKey = apiKey;
     
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         @synchronized (_eventsData) {
             if (userId != nil) {
                 [self setUserId:userId];
@@ -289,6 +291,22 @@ AMPLocationManagerDelegate *locationManagerDelegate;
     }];
 
     _initialized = YES;
+}
+
+/**
+ * Run a block in the background. If already in the background, run immediately.
+ */
+- (BOOL)runOnBackgroundQueue:(void (^)(void))block
+{
+    if ([[NSOperationQueue currentQueue].name isEqualToString:@"BACKGROUND"]) {
+        NSLog(@"Already running in the background.");
+        block();
+        return NO;
+    }
+    else {
+        [_backgroundQueue addOperationWithBlock:block];
+        return YES;
+    }
 }
 
 #pragma mark - logEvent
@@ -323,7 +341,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         timestamp = [NSNumber numberWithLongLong:[[NSDate date] timeIntervalSince1970] * 1000];
     }
     
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         
         NSMutableDictionary *event = [NSMutableDictionary dictionary];
 
@@ -490,7 +508,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
 {
     updateScheduled = NO;
     
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         [self uploadEvents];
     }];
 }
@@ -514,7 +532,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         updatingCurrently = YES;
     }
     
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         
         @synchronized (_eventsData) {
             // Don't communicate with the server if the user has opted out.
@@ -670,7 +688,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         [[UIApplication sharedApplication] endBackgroundTask:uploadTaskID];
         uploadTaskID = UIBackgroundTaskInvalid;
     }
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         [self uploadEvents];
     }];
 }
@@ -689,7 +707,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
     }];
 
     [self endSession];
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         [self saveEventsData];
         [self uploadEventsWithLimit:0];
     }];
@@ -708,37 +726,33 @@ AMPLocationManagerDelegate *locationManagerDelegate;
                                                    object:self];
     }];
     
-    [_backgroundQueue addOperationWithBlock:^{
-        
+    [self runOnBackgroundQueue:^{
         @synchronized (_eventsData) {
-            
             // Session has not been started yet, check overlap with previous session
             NSNumber *previousSessionTime = [_eventsData objectForKey:@"previous_session_time"];
             long long timeDelta = [now longLongValue] - [previousSessionTime longLongValue];
             
-            if (!sessionStarted || _sessionId < 0) {
-                if (timeDelta < kAMPMinTimeBetweenSessionsMillis) {
-                    _sessionId = [[_eventsData objectForKey:@"previous_session_id"] longLongValue];
-                } else {
-                    _sessionId = [now longLongValue];
-                    [_eventsData setValue:[NSNumber numberWithLongLong:_sessionId] forKey:@"previous_session_id"];
-                }
-            } else {
-                if (timeDelta > kAMPSessionTimeoutMillis) {
-                    // Session has expired
-                    _sessionId = [now longLongValue];
-                    [_eventsData setValue:[NSNumber numberWithLongLong:_sessionId] forKey:@"previous_session_id"];
-                }
-                // else _sessionId = previous session id
-            }
-        }
-        
-        sessionStarted = YES;
-    }];
+            BOOL sessionExists = sessionStarted && _sessionId >= 0;
+            BOOL sessionExpired = timeDelta > kAMPSessionTimeoutMillis;
 
-    NSMutableDictionary *apiProperties = [NSMutableDictionary dictionary];
-    [apiProperties setValue:@"session_start" forKey:@"special"];
-    [self logEvent:@"session_start" withEventProperties:nil apiProperties:apiProperties withTimestamp:now];
+            if (!sessionExists && timeDelta < kAMPMinTimeBetweenSessionsMillis) {
+                // The previous session happened recently enough to be considered the same session. Use it.
+                _sessionId = [[_eventsData objectForKey:@"previous_session_id"] longLongValue];
+            } else if (!sessionExists || sessionExpired) {
+                // Session has expired or doesn't exist.
+                _sessionId = [now longLongValue];
+                [_eventsData setValue:[NSNumber numberWithLongLong:_sessionId] forKey:@"previous_session_id"];
+            }
+            // else _sessionId = previous session id
+
+            if (!sessionStarted) {
+                NSMutableDictionary *apiProperties = [NSMutableDictionary dictionary];
+                [apiProperties setValue:@"session_start" forKey:@"special"];
+                [self logEvent:@"session_start" withEventProperties:nil apiProperties:apiProperties withTimestamp:now];
+            }
+            sessionStarted = YES;
+        }
+    }];
 }
 
 - (void)endSession
@@ -747,8 +761,10 @@ AMPLocationManagerDelegate *locationManagerDelegate;
     [apiProperties setValue:@"session_end" forKey:@"special"];
     [self logEvent:@"session_end" withEventProperties:nil apiProperties:apiProperties withTimestamp:nil];
     
-    [_backgroundQueue addOperationWithBlock:^{
-        sessionStarted = NO;
+    [self runOnBackgroundQueue:^{
+        @synchronized (_eventsData) {
+            sessionStarted = NO;
+        }
     }];
     
     [mainQueue addOperationWithBlock:^{
@@ -765,7 +781,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
 
 - (void)turnOffSessionLaterExecute
 {
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         if (!sessionStarted) {
             _sessionId = -1;
         }
@@ -806,7 +822,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
         return;
     }
     
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         (void) SAFE_ARC_RETAIN(userId);
         SAFE_ARC_RELEASE(_userId);
         _userId = userId;
@@ -819,7 +835,7 @@ AMPLocationManagerDelegate *locationManagerDelegate;
 
 - (void)setOptOut:(BOOL)enabled
 {
-    [_backgroundQueue addOperationWithBlock:^{
+    [self runOnBackgroundQueue:^{
         @synchronized (_eventsData) {
             [_eventsData setObject:[NSNumber numberWithBool:enabled] forKey:@"opt_out"];
             [self saveEventsData];

--- a/Amplitude/CHANGELOG.md
+++ b/Amplitude/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
 
-* Fix duplicate session starts when tracking silent push notifications.
-* Refactor module-scope variables into instance variables for testing.
+* No longer starts a session automatically if app is opened in background.
+* Add initialization method with argument to choose if a session is started on init.
+* Refactor module-scope variables into instance variables.

--- a/Amplitude/CHANGELOG.md
+++ b/Amplitude/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Unreleased
+
+* Fix duplicate session starts when tracking silent push notifications.
+* Refactor module-scope variables into instance variables for testing.

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -1,0 +1,122 @@
+//
+//  SessionTests.m
+//  SessionTests
+//
+//  Created by Curtis on 9/24/14.
+//  Copyright (c) 2014 Amplitude. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <UIKit/UIKit.h>
+#import <OCMock/OCMock.h>
+#import "Amplitude.h"
+#import "Amplitude+Test.h"
+#import "BaseTestCase.h"
+
+@interface SessionTests : BaseTestCase
+
+@end
+
+@implementation SessionTests { }
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testSessionAutoStarted {
+    [self.amplitude initializeApiKey:apiKey];
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 1);
+    XCTAssert([[self.amplitude getLastEvent][@"event_type"] isEqualToString:@"session_start"]);
+}
+
+- (void)testSessionAutoStartedBackground {
+    id mockApplication = [OCMockObject niceMockForClass:[UIApplication class]];
+    [[[mockApplication stub] andReturn:mockApplication] sharedApplication];
+    OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateBackground);
+
+    [self.amplitude initializeApiKey:apiKey];
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 0);
+
+    [mockApplication stopMocking];
+}
+
+- (void)testSessionAutoStartedInactive {
+    id mockApplication = [OCMockObject niceMockForClass:[UIApplication class]];
+    [[[mockApplication stub] andReturn:mockApplication] sharedApplication];
+    OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateInactive);
+
+    [self.amplitude initializeApiKey:apiKey];
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 1);
+    XCTAssert([[self.amplitude getLastEvent][@"event_type"] isEqualToString:@"session_start"]);
+
+    [mockApplication stopMocking];
+}
+
+- (void)testSessionStarted {
+    [self.amplitude initializeApiKey:apiKey userId:nil startSession:YES];
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 1);
+    XCTAssert([[self.amplitude getLastEvent][@"event_type"] isEqualToString:@"session_start"]);
+}
+
+- (void)testSessionNotStarted {
+    [self.amplitude initializeApiKey:apiKey userId:nil startSession:NO];
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 0);
+}
+
+/**
+ * Any number of session start calls should only generate exactly one logged event.
+ */
+- (void)testStartSession {
+    [self.amplitude initializeApiKey:apiKey userId:nil startSession:NO];
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
+    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
+
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 1);
+
+    NSDictionary *event = [self.amplitude getLastEvent];
+    XCTAssert([event[@"event_type"] isEqualToString:@"session_start"]);
+    XCTAssertEqual(event[@"session_id"], event[@"timestamp"]);
+}
+
+- (void)testSessionEnd {
+    [self.amplitude initializeApiKey:apiKey userId:nil startSession:NO];
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil userInfo:nil];
+
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 1);
+    XCTAssert([[self.amplitude getEvent:0][@"event_type"] isEqualToString:@"session_end"]);
+}
+
+/**
+ * Ending a session should case another start session event to be logged.
+ */
+- (void)testSessionRestart {
+    [self.amplitude initializeApiKey:apiKey userId:nil startSession:NO];
+
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
+    [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil userInfo:nil];
+    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
+
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 3);
+    XCTAssert([[self.amplitude getEvent:0][@"event_type"] isEqualToString:@"session_start"]);
+    XCTAssert([[self.amplitude getEvent:1][@"event_type"] isEqualToString:@"session_end"]);
+    XCTAssert([[self.amplitude getEvent:2][@"event_type"] isEqualToString:@"session_start"]);
+}
+
+@end

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -101,6 +101,18 @@
     XCTAssert([[self.amplitude getEvent:0][@"event_type"] isEqualToString:@"session_end"]);
 }
 
+- (void)testManualStartSession {
+    [self.amplitude initializeApiKey:apiKey userId:nil startSession:NO];
+
+    [self.amplitude startSession];
+
+    [self.amplitude flushQueue];
+    XCTAssertEqual([self.amplitude queuedEventCount], 1);
+
+    NSDictionary *event = [self.amplitude getLastEvent];
+    XCTAssert([event[@"event_type"] isEqualToString:@"session_start"]);
+    XCTAssertEqual(event[@"session_id"], event[@"timestamp"]);
+}
 /**
  * Ending a session should case another start session event to be logged.
  */

--- a/AmplitudeTests/SetupTests.m
+++ b/AmplitudeTests/SetupTests.m
@@ -58,50 +58,6 @@
     XCTAssert([self.amplitude initialized]);
 }
 
-/**
- * Any number of session start calls should only generate exactly one logged event.
- */
-- (void)testStartSession {
-    [self.amplitude initializeApiKey:apiKey];
-
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
-    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
-
-    [self.amplitude flushQueue];
-    XCTAssertEqual([self.amplitude queuedEventCount], 1);
-    XCTAssert([[self.amplitude getLastEvent][@"event_type"] isEqualToString:@"session_start"]);
-}
-
-- (void)testSessionEnd {
-    [self.amplitude initializeApiKey:apiKey];
-
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil userInfo:nil];
-
-    [self.amplitude flushQueue];
-    XCTAssertEqual([self.amplitude queuedEventCount], 1);
-    XCTAssert([[self.amplitude getEvent:0][@"event_type"] isEqualToString:@"session_end"]);
-}
-
-/**
- * Ending a session should case another start session event to be logged.
- */
-- (void)testSessionRestart {
-    [self.amplitude initializeApiKey:apiKey];
-
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
-    [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil userInfo:nil];
-    [center postNotificationName:UIApplicationDidBecomeActiveNotification object:nil userInfo:nil];
-
-    [self.amplitude flushQueue];
-    XCTAssertEqual([self.amplitude queuedEventCount], 3);
-    XCTAssert([[self.amplitude getEvent:0][@"event_type"] isEqualToString:@"session_start"]);
-    XCTAssert([[self.amplitude getEvent:1][@"event_type"] isEqualToString:@"session_end"]);
-    XCTAssert([[self.amplitude getEvent:2][@"event_type"] isEqualToString:@"session_start"]);
-}
-
 - (void)testOptOut {
     [self.amplitude initializeApiKey:apiKey];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+* Expose :startSession publicly. Can be used to start a session for a user
+  interaction that happens while the app is in the background, for example,
+  changing tracks on background audio.
+* No longer starts a session if the app is in the background when the SDK is
+  initialized. Prevents logging of silent push notifications from starting
+  a session and counting a user visit. This changes the previous default
+  behavior. To maintain the previous behavior, use
+  :initializeApiKey:apiKey:userId:startSession and set startSession to true.
 
 ## 2.3.0 (March 21, 2015)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ It's important to think about what types of events you care about as a developer
 
 A session is a period of time that a user has the app in the foreground. Sessions within 10 seconds of each other are merged into a single session. In the iOS SDK, sessions are tracked automatically.
 
+If your users can take actions while the app is in the background and you would like to track a user session for those actions, use the ```startSession``` method.
+
+``` objective-c
+MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+[commandCenter.nextTrackCommand addTargetUsingBlock:^(MPRemoteCommandEvent *event) {
+  [[Amplitude instance] startSession]
+  [Amplitude logEvent:@"Skip Track"];
+}]
+```
+
+Or, you may want to track a session for interactions with push notification actions. In that case, call ```startSession``` or use ```initializeApiKey:apiKey:userId:startSession``` from ```application:handleActionWithIdentifier:forRemoteNotification:completionHandler:``` or ```application:handleActionWithIdentifier:forLocalNotification:completionHandler:```
+
+``` objective-c
+- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void (^)())completionHandler {
+  [[Amplitude instance] initializeApiKey:@"KEY" userId:nil startSession:YES];
+  if ([identifier isEqualToString:NotificationActionOneIdent]) {
+    [Amplitude logEvent:@"Action One"];
+  }
+}
+```
+
 # Setting Custom User IDs #
 
 If your app has its own login system that you want to track users with, you can call `setUserId:` at any time:


### PR DESCRIPTION
Start sessions on didBecomeActive instead of willEnterForeground and don't start a session during module initialization. This stops a session from being started when a silent push notif is tracked (the app never becomes active).

In the usual case (user starts app from the icon or from an alerting push notif), the app starts, Amplitude is initialized with an api key, and the session is started when UIApplicationDidBecomeActiveNotification fires as the app UI takes over.

DidBecomeActive fires only slightly more often than WillEnterForeground. It may fire when a phone call is received while the app is open or after the user enters the task switcher or notification overlay. Since startSession doesn't start a new session if one is already active, that shouldn't cause issues. The calls to updateLocation and uploadEvents in enterForeground could be gated or moved to avoid the slight increase in overhead.

@curtisliu how does the API handle receiving an event with no session_id (or session_id of -1)? Or, is there a better way to indicate that no session exists?