### PR TITLE
Fix issue with events not being sent every x seconds.

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -554,9 +554,11 @@ NSString *const kAMPRevenueEvent = @"revenue_amount";
 {
     if (!_updateScheduled) {
         _updateScheduled = YES;
-        
+        __weak __typeof(self)weakSelf = self;
         [_backgroundQueue addOperationWithBlock:^{
-            [self performSelector:@selector(uploadEventsInBackground) withObject:nil afterDelay:delay];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [weakSelf performSelector:@selector(uploadEventsInBackground) withObject:nil afterDelay:delay];
+            });
         }];
     }
 }


### PR DESCRIPTION
performSelector:withObject:afterDelay is not working.

The performSelector timer is tied to the thread of the operation. Once the performSelector call is made the timer is released and uploadEventsInBackground is never called.

Reference to similar issue with performSelector:withObject:afterDelay
http://stackoverflow.com/questions/16956321/ios-performselectorwithobjectafterdelay-not-working