### PR TITLE
add the ability to set the device ID

### DIFF
--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -253,6 +253,19 @@
  @method
 
  @abstract
+ Sets the deviceId.
+
+ @param deviceId                  If your app has its own logic for tracking devices before a user logs in, set the device id
+
+ @discussion
+ If your app has its own logic for tracking devices before a user logs in, set the deviceId
+ */
+- (void)setDeviceId:(NSString*)deviceId;
+
+/*!
+ @method
+
+ @abstract
  Returns deviceId
 
  @discussion

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -1019,6 +1019,20 @@ NSString *const USER_ID = @"user_id";
     _userProperties = userProperties;
 }
 
+- (void)setDeviceId:(NSString*)deviceId
+{
+    if (!(deviceId == nil || [self isArgument:deviceId validType:[NSString class] methodName:@"setDeviceId:"])) {
+        return;
+    }
+
+    [self runOnBackgroundQueue:^{
+        SAFE_ARC_RETAIN(deviceId);
+        SAFE_ARC_RELEASE(_deviceId);
+        _deviceId = deviceId;
+        [[AMPDatabaseHelper getDatabaseHelper] insertOrReplaceKeyValue:DEVICE_ID value:_deviceId];
+    }];
+}
+
 - (void)setUserId:(NSString*) userId
 {
     if (!(userId == nil || [self isArgument:userId validType:[NSString class] methodName:@"setUserId:"])) {


### PR DESCRIPTION
This was a response to a thread Xin and @coderholic and I had about setting the device ID.  This is important to our needs.  The javascript SDK allows setting the device ID.

If you want more context about our reasoning let me know and I'd be happy to provide.