### PR TITLE
don't check session when sending session events

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -501,12 +501,13 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             return;
         }
 
-        NSMutableDictionary *event = [NSMutableDictionary dictionary];
-
-        if (!outOfSession) {
+        // skip session check if logging start_session or end_session events
+        BOOL loggingSessionEvent = _trackingSessionEvents && ([eventType isEqualToString:kAMPSessionStartEvent] || [eventType isEqualToString:kAMPSessionEndEvent]);
+        if (!loggingSessionEvent && !outOfSession) {
             [self startOrContinueSession:timestamp];
         }
 
+        NSMutableDictionary *event = [NSMutableDictionary dictionary];
         [event setValue:eventType forKey:@"event_type"];
         [event setValue:[self replaceWithEmptyJSON:[self truncate:eventProperties]] forKey:@"event_properties"];
         [event setValue:[self replaceWithEmptyJSON:apiProperties] forKey:@"api_properties"];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Handle NaNs and exceptions from NSJSONSerialization during event data migration.
+* Fix bug where logEvent checks session when logging start/end session events.
 
 ## 3.2.0 (October 20, 2015)
 


### PR DESCRIPTION
Following the logic from the Android SDK: https://github.com/amplitude/Amplitude-Android/blob/master/src/com/amplitude/api/AmplitudeClient.java#L327-L330

Reproduced infinite loop in tests and verified that patch fixes the loop