### PR TITLE
add OSX support

### DIFF
--- a/Amplitude/AMPLocationManagerDelegate.m
+++ b/Amplitude/AMPLocationManagerDelegate.m
@@ -19,11 +19,16 @@
 {
     // kCLAuthorizationStatusAuthorized is deprecated in iOS 8. Add support for
     // the new location authorization types if we're compiling for iOS 8 or higher.
-#ifdef __IPHONE_8_0
+#if TARGET_OS_IPHONE
+  #ifdef __IPHONE_8_0
     if (status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse) {
+  #else
+    if (status == kCLAuthorizationStatusAuthorized) {
+  #endif
 #else
     if (status == kCLAuthorizationStatusAuthorized) {
 #endif
+
         SEL updateLocation = NSSelectorFromString(@"updateLocation");
         [Amplitude performSelector:updateLocation];
     }


### PR DESCRIPTION
This pull request adds OS X support to the amplitude iOS lib.

We're running this in production with https://itunes.apple.com/us/app/keep-safe-private-photo-vault/id1078477965?ls=1&mt=12

The only open question is, who to define sessions on the desktop. It's not as obvious as on mobile because of multi task.

CC @curtisliu PR based on our email conversation.
