### PR TITLE
Add Wrapper to Un-Set User Properties

### DIFF
--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -214,6 +214,19 @@
  @method
 
  @abstract
+ Removes properties that are tracked on the user level.
+
+ @param userProperties          An NSArray containing the keys of the properties to be removed.
+
+ @discussion
+ Property keys must be <code>NSString</code> objects.
+ */
+- (void)unsetUserProperties:(NSArray*) userProperties;
+
+/*!
+ @method
+
+ @abstract
  Sets the userId.
 
  @param userId                  If your app has its own login system that you want to track users with, you can set the userId.

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -153,6 +153,10 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [[Amplitude instance] setUserProperties:userProperties];
 }
 
++ (void)unsetUserProperties:(NSArray*) userProperties {
+    [[Amplitude instance] unsetUserProperties:userProperties];
+}
+
 + (void)setUserId:(NSString*) userId {
     [[Amplitude instance] setUserId:userId];
 }
@@ -1180,6 +1184,22 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 {
     AMPIdentify *identify = [[AMPIdentify identify] clearAll];
     [self identify:identify];
+}
+
+- (void)unsetUserProperties:(NSArray*) userProperties
+{
+    if (userProperties == nil || ![self isArgument:userProperties validType:[NSArray class] methodName:@"unsetUserProperties:"] || [userProperties count] == 0) {
+        return;
+    }
+
+    NSArray *copy = [userProperties copy];
+    [self runOnBackgroundQueue:^{
+        AMPIdentify *identify = [AMPIdentify identify];
+        for (NSString *key in copy) {
+            [identify unset:key];
+        }
+        [self identify:identify];
+    }];
 }
 
 - (void)setUserId:(NSString*) userId

--- a/AmplitudeTests/SetupTests.m
+++ b/AmplitudeTests/SetupTests.m
@@ -103,6 +103,32 @@
     XCTAssertEqual(1, [[event objectForKey:@"sequence_number"] intValue]);
 }
 
+- (void)testUserPropertiesUnset {
+    [self.amplitude initializeApiKey:apiKey];
+    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
+    XCTAssertEqual([dbHelper getEventCount], 0);
+
+    NSDictionary *properties = @{
+         @"shoeSize": @"-",
+         @"hatSize":  @"-",
+         @"name": @"-"
+    };
+
+    [self.amplitude unsetUserProperties:[properties allKeys]];
+    [self.amplitude flushQueue];
+    XCTAssertEqual([dbHelper getEventCount], 0);
+    XCTAssertEqual([dbHelper getIdentifyCount], 1);
+    XCTAssertEqual([dbHelper getTotalEventCount], 1);
+
+    NSDictionary *expected = [NSDictionary dictionaryWithObject:properties forKey:AMP_OP_UNSET];
+
+    NSDictionary *event = [self.amplitude getLastIdentify];
+    XCTAssertEqualObjects([event objectForKey:@"event_type"], IDENTIFY_EVENT);
+    XCTAssertEqualObjects([event objectForKey:@"user_properties"], expected);
+    XCTAssertEqualObjects([event objectForKey:@"event_properties"], [NSDictionary dictionary]); // event properties should be empty
+    XCTAssertEqual(1, [[event objectForKey:@"sequence_number"] intValue]);
+}
+
 - (void)testSetDeviceId {
     AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Add support for logging events to multiple Amplitude apps. See [Readme](https://github.com/amplitude/Amplitude-iOS#tracking-events-to-multiple-amplitude-apps) for details.
+* Add shorthand method to unset user properties
 
 ## 3.5.0 (January 15, 2016)
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ You may use `clearUserProperties` to clear all user properties at once. Note: th
 [[Amplitude instance] clearUserProperties];
 ```
 
+### Clearing User Properties with `unsetUserProperties` ###
+
+You may use `unsetUserProperties` shorthand to unset multiple user properties at once. This method is simply a wrapper around `AMPIDentify unset` and `identify`.
+
 # Allowing Users to Opt Out
 
 To stop all event and session logging for a user, call setOptOut:


### PR DESCRIPTION
Adds unsetUserProperties wrapper function. This is meant to make it much easier for Unity to access this functionality.