### PR TITLE
Make compatible with iOS Extensions

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		E98C05351A48E7FE00800C63 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -512,6 +513,7 @@
 		E98C05361A48E7FE00800C63 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
I screwed up my last remote branch, so trying again...

I'm trying to use the sdk with a keyboard extension. Unfortunately, sharedApplication is unavailable in iOS extensions.

This diff replaces calls to sharedApplication with performSelector. This has been done in other places like SDWebImage here: rs/SDWebImage#1082 and doesn't appear to present any issues with App Store review.