### PR TITLE
Revenue v2

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		321B1765FE30892CC6A0E979 /* libPods-test.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BB69FAEFF28EED71342290C /* libPods-test.a */; };
+		60227C0B1CC5AB8A007C117B /* AMPRevenue.m in Sources */ = {isa = PBXBuildFile; fileRef = 60227C0A1CC5AB8A007C117B /* AMPRevenue.m */; };
+		60227C0C1CC5AC2F007C117B /* AMPRevenue.m in Sources */ = {isa = PBXBuildFile; fileRef = 60227C0A1CC5AB8A007C117B /* AMPRevenue.m */; };
+		60227C0E1CC5BC07007C117B /* RevenueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60227C0D1CC5BC07007C117B /* RevenueTests.m */; };
 		602A9A6B1B754E7B0067230C /* AmplitudeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 602A9A6A1B754E7B0067230C /* AmplitudeTests.m */; };
 		60BA92771C2376680043178E /* AMPDatabaseHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BA92721C2376680043178E /* AMPDatabaseHelper.m */; };
 		60BA92781C2376680043178E /* AMPIdentify.m in Sources */ = {isa = PBXBuildFile; fileRef = 60BA92741C2376680043178E /* AMPIdentify.m */; };
@@ -58,6 +61,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		60227C091CC5AB8A007C117B /* AMPRevenue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPRevenue.h; sourceTree = "<group>"; };
+		60227C0A1CC5AB8A007C117B /* AMPRevenue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPRevenue.m; sourceTree = "<group>"; };
+		60227C0D1CC5BC07007C117B /* RevenueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RevenueTests.m; sourceTree = "<group>"; };
 		602A9A6A1B754E7B0067230C /* AmplitudeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AmplitudeTests.m; sourceTree = "<group>"; };
 		60BA92711C2376680043178E /* AMPDatabaseHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPDatabaseHelper.h; sourceTree = "<group>"; };
 		60BA92721C2376680043178E /* AMPDatabaseHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPDatabaseHelper.m; sourceTree = "<group>"; };
@@ -193,6 +199,8 @@
 				9DC708561AD4A49E00949778 /* Amplitude+SSLPinning.h */,
 				E96785E81A48E93F00887CCD /* AMPLocationManagerDelegate.h */,
 				E96785E91A48E93F00887CCD /* AMPLocationManagerDelegate.m */,
+				60227C091CC5AB8A007C117B /* AMPRevenue.h */,
+				60227C0A1CC5AB8A007C117B /* AMPRevenue.m */,
 				9D40E1791AB3BF7F0095C7C6 /* AMPURLConnection.h */,
 				9D40E17A1AB3BF7F0095C7C6 /* AMPURLConnection.m */,
 				60BA92751C2376680043178E /* AMPUtils.h */,
@@ -207,6 +215,7 @@
 		E98C052F1A48E7FE00800C63 /* AmplitudeTests */ = {
 			isa = PBXGroup;
 			children = (
+				60227C0D1CC5BC07007C117B /* RevenueTests.m */,
 				60BA927D1C23768E0043178E /* AMPDatabaseHelperTests.m */,
 				9DFBB9C51AB0D1DD0017F703 /* Amplitude+Test.h */,
 				9DFBB9C61AB0D1DD0017F703 /* Amplitude+Test.m */,
@@ -377,6 +386,7 @@
 				9D6E19541ACCDE1C00352C6C /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				60BA92771C2376680043178E /* AMPDatabaseHelper.m in Sources */,
 				60BA92781C2376680043178E /* AMPIdentify.m in Sources */,
+				60227C0B1CC5AB8A007C117B /* AMPRevenue.m in Sources */,
 				9D40E17E1AB3BF7F0095C7C6 /* AMPURLConnection.m in Sources */,
 				E96785EC1A48E93F00887CCD /* AMPDeviceInfo.m in Sources */,
 				E96785EE1A48E93F00887CCD /* AMPLocationManagerDelegate.m in Sources */,
@@ -403,6 +413,8 @@
 				60BA927C1C23767D0043178E /* AMPUtils.m in Sources */,
 				9DC7085B1AD4B28300949778 /* AMPConstants.m in Sources */,
 				60BA927B1C23767B0043178E /* AMPIdentify.m in Sources */,
+				60227C0E1CC5BC07007C117B /* RevenueTests.m in Sources */,
+				60227C0C1CC5AC2F007C117B /* AMPRevenue.m in Sources */,
 				9D82D1D81AC1006600C3F321 /* SetupTests.m in Sources */,
 				60BA927A1C2376770043178E /* AMPDatabaseHelper.m in Sources */,
 				9D265EF41AB3FA2500399D93 /* SSLPinningTests.m in Sources */,
@@ -426,7 +438,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -469,7 +481,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -501,7 +513,7 @@
 		E98C05351A48E7FE00800C63 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -512,7 +524,7 @@
 		E98C05361A48E7FE00800C63 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Amplitude/AMPConstants.h
+++ b/Amplitude/AMPConstants.h
@@ -27,3 +27,9 @@ extern NSString *const AMP_OP_PREPEND;
 extern NSString *const AMP_OP_SET;
 extern NSString *const AMP_OP_SET_ONCE;
 extern NSString *const AMP_OP_UNSET;
+
+extern NSString *const AMP_REVENUE_PRODUCT_ID;
+extern NSString *const AMP_REVENUE_QUANTITY;
+extern NSString *const AMP_REVENUE_PRICE;
+extern NSString *const AMP_REVENUE_REVENUE_TYPE;
+extern NSString *const AMP_REVENUE_RECEIPT;

--- a/Amplitude/AMPConstants.m
+++ b/Amplitude/AMPConstants.m
@@ -28,3 +28,9 @@ NSString *const AMP_OP_PREPEND = @"$prepend";
 NSString *const AMP_OP_SET = @"$set";
 NSString *const AMP_OP_SET_ONCE = @"$setOnce";
 NSString *const AMP_OP_UNSET = @"$unset";
+
+NSString *const AMP_REVENUE_PRODUCT_ID = @"$productId";
+NSString *const AMP_REVENUE_QUANTITY = @"$quantity";
+NSString *const AMP_REVENUE_PRICE = @"$price";
+NSString *const AMP_REVENUE_REVENUE_TYPE = @"$revenueType";
+NSString *const AMP_REVENUE_RECEIPT = @"$receipt";

--- a/Amplitude/AMPRevenue.h
+++ b/Amplitude/AMPRevenue.h
@@ -1,0 +1,31 @@
+//
+//  AMPRevenue.h
+//  Amplitude
+//
+//  Created by Daniel Jih on 04/18/16.
+//  Copyright © 2016 Amplitude. All rights reserved.
+//
+
+@interface AMPRevenue : NSObject
+
+// required fields
+@property (nonatomic, strong, readonly) NSString *productId;
+@property (nonatomic, readonly) NSInteger quantity;
+@property (nonatomic, strong, readonly) NSNumber *price;
+
+// optional fields
+@property (nonatomic, strong, readonly) NSString *revenueType;
+@property (nonatomic, strong, readonly) NSData *receipt;
+@property (nonatomic, strong, readonly) NSDictionary *properties;
+
++ (instancetype)revenue;
+- (BOOL) isValidRevenue;
+- (AMPRevenue*)setProductIdentifier:(NSString*) productIdentifier;
+- (AMPRevenue*)setQuantity:(NSInteger) quantity;
+- (AMPRevenue*)setPrice:(NSNumber*) price;
+- (AMPRevenue*)setRevenueType:(NSString*) revenueType;
+- (AMPRevenue*)setReceipt:(NSData*) receipt;
+- (AMPRevenue*)setRevenueProperties:(NSDictionary*) revenueProperties;
+- (NSDictionary*)toNSDictionary;
+
+@end

--- a/Amplitude/AMPRevenue.h
+++ b/Amplitude/AMPRevenue.h
@@ -25,7 +25,7 @@
 - (AMPRevenue*)setPrice:(NSNumber*) price;
 - (AMPRevenue*)setRevenueType:(NSString*) revenueType;
 - (AMPRevenue*)setReceipt:(NSData*) receipt;
-- (AMPRevenue*)setRevenueProperties:(NSDictionary*) revenueProperties;
+- (AMPRevenue*)setEventProperties:(NSDictionary*) eventProperties;
 - (NSDictionary*)toNSDictionary;
 
 @end

--- a/Amplitude/AMPRevenue.m
+++ b/Amplitude/AMPRevenue.m
@@ -1,0 +1,133 @@
+//
+//  AMPRevenue.m
+//  Amplitude
+//
+//  Created by Daniel Jih on 04/18/16.
+//  Copyright © 2016 Amplitude. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "AMPRevenue.h"
+#import "AMPARCMacros.h"
+#import "AMPConstants.h"
+#import "AMPUtils.h"
+
+@interface AMPRevenue()
+@end
+
+@implementation AMPRevenue{}
+
+- (void)dealloc
+{
+    SAFE_ARC_RELEASE(_productId);
+    SAFE_ARC_RELEASE(_price);
+    SAFE_ARC_RELEASE(_revenueType);
+    SAFE_ARC_RELEASE(_receipt);
+    SAFE_ARC_RELEASE(_properties);
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+- (id)init
+{
+    if (self = [super init]) {
+        _quantity = 1;
+    }
+    return self;
+}
+
++ (instancetype)revenue
+{
+    return SAFE_ARC_AUTORELEASE([[self alloc] init]);
+}
+
+- (BOOL)isValidRevenue
+{
+    if ([AMPUtils isEmptyString:_productId]) {
+        NSLog(@"Invalid revenue, need to set productId field");
+        return NO;
+    }
+    if (_price == nil) {
+        NSLog(@"Invalid revenue, need to set price field");
+        return NO;
+    }
+    return YES;
+}
+
+- (AMPRevenue*)setProductIdentifier:(NSString *) productIdentifier
+{
+    if ([AMPUtils isEmptyString:productIdentifier]) {
+        NSLog(@"Invalid empty productIdentifier");
+        return self;
+    }
+
+    SAFE_ARC_RETAIN(productIdentifier);
+    SAFE_ARC_RELEASE(_productId);
+    _productId = productIdentifier;
+    return self;
+}
+
+- (AMPRevenue*)setQuantity:(NSInteger) quantity
+{
+    _quantity = quantity;
+    return self;
+}
+
+- (AMPRevenue*)setPrice:(NSNumber *) price
+{
+    SAFE_ARC_RETAIN(price);
+    SAFE_ARC_RELEASE(_price);
+    _price = price;
+    return self;
+}
+
+- (AMPRevenue*)setRevenueType:(NSString*) revenueType
+{
+    SAFE_ARC_RETAIN(revenueType);
+    SAFE_ARC_RELEASE(_revenueType);
+    _revenueType = revenueType;
+    return self;
+}
+
+- (AMPRevenue*)setReceipt:(NSData*) receipt
+{
+    SAFE_ARC_RETAIN(receipt);
+    SAFE_ARC_RELEASE(_receipt);
+    _receipt = receipt;
+    return self;
+}
+
+- (AMPRevenue*)setRevenueProperties:(NSDictionary*) revenueProperties
+{
+    revenueProperties = [revenueProperties copy];
+    SAFE_ARC_RELEASE(_properties);
+    _properties = revenueProperties;
+    return self;
+}
+
+- (NSDictionary*)toNSDictionary
+{
+    NSMutableDictionary *dict;
+    if (_properties == nil) {
+        dict = [[NSMutableDictionary alloc] init];
+    } else {
+        dict = [_properties mutableCopy];
+    }
+
+    [dict setValue:_productId forKey:AMP_REVENUE_PRODUCT_ID];
+    [dict setValue:[NSNumber numberWithInteger:_quantity] forKey:AMP_REVENUE_QUANTITY];
+    [dict setValue:_price forKey:AMP_REVENUE_PRICE];
+    [dict setValue:_revenueType forKey:AMP_REVENUE_REVENUE_TYPE];
+
+    if ([_receipt respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
+        [dict setValue:[_receipt base64EncodedStringWithOptions:0] forKey:AMP_REVENUE_RECEIPT];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+        [dict setValue:[_receipt base64Encoding] forKey:AMP_REVENUE_RECEIPT];
+#pragma clang diagnostic pop
+    }
+
+    return SAFE_ARC_AUTORELEASE(dict);
+}
+
+@end

--- a/Amplitude/AMPRevenue.m
+++ b/Amplitude/AMPRevenue.m
@@ -96,11 +96,11 @@
     return self;
 }
 
-- (AMPRevenue*)setRevenueProperties:(NSDictionary*) revenueProperties
+- (AMPRevenue*)setEventProperties:(NSDictionary*) eventProperties
 {
-    revenueProperties = [revenueProperties copy];
+    eventProperties = [eventProperties copy];
     SAFE_ARC_RELEASE(_properties);
-    _properties = revenueProperties;
+    _properties = eventProperties;
     return self;
 }
 

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #import "AMPIdentify.h"
+#import "AMPRevenue.h"
 
 
 /*!
@@ -154,6 +155,24 @@
 - (void)logRevenue:(NSNumber*) amount;
 - (void)logRevenue:(NSString*) productIdentifier quantity:(NSInteger) quantity price:(NSNumber*) price;
 - (void)logRevenue:(NSString*) productIdentifier quantity:(NSInteger) quantity price:(NSNumber*) price receipt:(NSData*) receipt;
+
+/*!
+ @method
+ 
+ @abstract
+ Tracks revenue - API v2.
+ 
+ @param AMPRevenue object       revenue object contains all revenue information
+ 
+ @discussion
+ To track revenue from a user, create an AMPRevenue object each time the user generates revenue, and set the revenue properties (productIdentifier, price, quantity).
+ logRevenuev2: takes in an AMPRevenue object. This allows us to automatically display data relevant to revenue on the Amplitude website, including average
+ revenue per daily active user (ARPDAU), 7, 30, and 90 day revenue, lifetime value (LTV) estimates, and revenue by advertising campaign cohort and
+ daily/weekly/monthly cohorts.
+ 
+ For validating revenue, make sure the receipt data is set on the AMPRevenue object.
+ */
+- (void)logRevenueV2:(AMPRevenue*) revenue;
 
 /*!
  @method

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -23,6 +23,7 @@
 #import "AMPDatabaseHelper.h"
 #import "AMPUtils.h"
 #import "AMPIdentify.h"
+#import "AMPRevenue.h"
 #import <math.h>
 #import <sys/socket.h>
 #import <sys/sysctl.h>
@@ -688,6 +689,19 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 
     [self logEvent:kAMPRevenueEvent withEventProperties:nil withApiProperties:apiProperties withUserProperties:nil withTimestamp:nil outOfSession:NO];
+}
+
+- (void)logRevenueV2:(AMPRevenue*) revenue
+{
+    if (_apiKey == nil) {
+        NSLog(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logRevenueV2");
+        return;
+    }
+    if (revenue == nil || ![revenue isValidRevenue]) {
+        return;
+    }
+
+    [self logEvent:kAMPRevenueEvent withEventProperties:[revenue toNSDictionary]];
 }
 
 #pragma mark - Upload events

--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -349,7 +349,7 @@
     NSString *revenueType = @"testRevenueType";
     NSDictionary *props = [NSDictionary dictionaryWithObject:@"San Francisco" forKey:@"city"];
     AMPRevenue *revenue = [[[[AMPRevenue revenue] setProductIdentifier:productId] setPrice:price] setQuantity:quantity];
-    [[revenue setRevenueType:revenueType] setRevenueProperties:props];
+    [[revenue setRevenueType:revenueType] setEventProperties:props];
 
     [self.amplitude logRevenueV2:revenue];
     [self.amplitude flushQueue];

--- a/AmplitudeTests/RevenueTests.m
+++ b/AmplitudeTests/RevenueTests.m
@@ -1,0 +1,142 @@
+//
+//  RevenueTests.m
+//  Amplitude
+//
+//  Created by Daniel Jih on 04/18/16.
+//  Copyright © 2016 Amplitude. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AMPRevenue.h"
+#import "AMPARCMacros.h"
+#import "AMPConstants.h"
+
+@interface RevenueTests : XCTestCase
+
+@end
+
+@implementation RevenueTests { }
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testProductId {
+    AMPRevenue *revenue = [AMPRevenue revenue];
+    XCTAssertNil(revenue.productId);
+
+    NSString *productId = @"testProductId";
+    [revenue setProductIdentifier:productId];
+    XCTAssertEqualObjects(revenue.productId, productId);
+
+    // test that ignore empty inputs
+    [revenue setProductIdentifier:nil];
+    XCTAssertEqualObjects(revenue.productId, productId);
+    [revenue setProductIdentifier:@""];
+    XCTAssertEqualObjects(revenue.productId, productId);
+
+    NSDictionary *dict = [revenue toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"$productId"], productId);
+}
+
+- (void)testQuantity {
+    AMPRevenue *revenue = [AMPRevenue revenue];
+    XCTAssertEqual(revenue.quantity, 1);
+
+    NSInteger quantity = 100;
+    [revenue setQuantity:quantity];
+    XCTAssertEqual(revenue.quantity, quantity);
+
+    NSDictionary *dict = [revenue toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"$quantity"], [NSNumber numberWithInteger:quantity]);
+}
+
+- (void)testPrice {
+    AMPRevenue *revenue = [AMPRevenue revenue];
+    XCTAssertNil(revenue.price);
+
+    NSNumber *price = [NSNumber numberWithDouble:10.99];
+    [revenue setPrice:price];
+    XCTAssertEqualObjects(revenue.price, price);
+
+    NSDictionary *dict = [revenue toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"$price"], price);
+}
+
+- (void)testRevenueType {
+    AMPRevenue *revenue = [AMPRevenue revenue];
+    XCTAssertNil(revenue.revenueType);
+
+    NSString *revenueType = @"testRevenueType";
+    [revenue setRevenueType:revenueType];
+    XCTAssertEqualObjects(revenue.revenueType, revenueType);
+
+    // verify that null and empty strings allowed
+    [revenue setRevenueType:nil];
+    XCTAssertNil(revenue.revenueType);
+    [revenue setRevenueType:@""];
+    XCTAssertEqualObjects(revenue.revenueType, @"");
+
+    [revenue setRevenueType:revenueType];
+    XCTAssertEqualObjects(revenue.revenueType, revenueType);
+
+    NSDictionary *dict = [revenue toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"$revenueType"], revenueType);
+}
+
+- (void)testRevenueProperties {
+    AMPRevenue *revenue = [AMPRevenue revenue];
+    XCTAssertNil(revenue.properties);
+
+    NSDictionary *props = [NSDictionary dictionaryWithObject:@"Boston" forKey:@"city"];
+    [revenue setRevenueProperties:props];
+    XCTAssertEqualObjects(revenue.properties, props);
+
+    NSDictionary *dict = [revenue toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"city"], @"Boston");
+    XCTAssertEqualObjects([dict objectForKey:@"$quantity"], [NSNumber numberWithInt:1]);
+
+    // assert original dict was not modified
+    XCTAssertNil([props objectForKey:@"$quantity"]);
+}
+
+- (void)testValidRevenue {
+    AMPRevenue *revenue = [AMPRevenue revenue];
+    XCTAssertFalse([revenue isValidRevenue]);
+    [revenue setProductIdentifier:@"testProductId"];
+    XCTAssertFalse([revenue isValidRevenue]);
+    [revenue setPrice:[NSNumber numberWithDouble:10.99]];
+    XCTAssertTrue([revenue isValidRevenue]);
+
+    AMPRevenue *revenue2 = [AMPRevenue revenue];
+    XCTAssertFalse([revenue2 isValidRevenue]);
+    [revenue2 setPrice:[NSNumber numberWithDouble:10.99]];
+    [revenue2 setQuantity:10];
+    XCTAssertFalse([revenue2 isValidRevenue]);
+    [revenue2 setProductIdentifier:@"testProductId"];
+    XCTAssertTrue([revenue2 isValidRevenue]);
+}
+
+- (void)testToNSDictionary {
+    NSNumber *price = [NSNumber numberWithDouble:15.99];
+    NSInteger quantity = 15;
+    NSString *productId = @"testProductId";
+    NSString *revenueType = @"testRevenueType";
+    NSDictionary *props = [NSDictionary dictionaryWithObject:@"San Francisco" forKey:@"city"];
+
+    AMPRevenue *revenue = [[[[AMPRevenue revenue] setProductIdentifier:productId] setPrice:price] setQuantity:quantity];
+    [[revenue setRevenueType:revenueType] setRevenueProperties:props];
+
+    NSDictionary *dict = [revenue toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"$productId"], productId);
+    XCTAssertEqualObjects([dict objectForKey:@"$price"], price);
+    XCTAssertEqualObjects([dict objectForKey:@"$quantity"], [NSNumber numberWithInteger:quantity]);
+    XCTAssertEqualObjects([dict objectForKey:@"$revenueType"], revenueType);
+    XCTAssertEqualObjects([dict objectForKey:@"city"], @"San Francisco");
+}
+
+@end

--- a/AmplitudeTests/RevenueTests.m
+++ b/AmplitudeTests/RevenueTests.m
@@ -93,7 +93,7 @@
     XCTAssertNil(revenue.properties);
 
     NSDictionary *props = [NSDictionary dictionaryWithObject:@"Boston" forKey:@"city"];
-    [revenue setRevenueProperties:props];
+    [revenue setEventProperties:props];
     XCTAssertEqualObjects(revenue.properties, props);
 
     NSDictionary *dict = [revenue toNSDictionary];
@@ -129,7 +129,7 @@
     NSDictionary *props = [NSDictionary dictionaryWithObject:@"San Francisco" forKey:@"city"];
 
     AMPRevenue *revenue = [[[[AMPRevenue revenue] setProductIdentifier:productId] setPrice:price] setQuantity:quantity];
-    [[revenue setRevenueType:revenueType] setRevenueProperties:props];
+    [[revenue setRevenueType:revenueType] setEventProperties:props];
 
     NSDictionary *dict = [revenue toNSDictionary];
     XCTAssertEqualObjects([dict objectForKey:@"$productId"], productId);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 * Add helper method `getSessionId` to expose the current sessionId value.
-* Add logRevenueV2 and new Revenue class to support logging revenue events with properties, revenue type, and verified. See [Readme](https://github.com/amplitude/Amplitude-iOS#tracking-revenue) for more info.
+* Add logRevenueV2 and new Revenue class to support logging revenue events with properties, and revenue type. See [Readme](https://github.com/amplitude/Amplitude-iOS#tracking-revenue) for more info.
 
 ## 3.6.0 (March 28, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Add helper method `getSessionId` to expose the current sessionId value.
+* Add logRevenueV2 and new Revenue class to support logging revenue events with properties, revenue type, and verified. See [Readme](https://github.com/amplitude/Amplitude-iOS#tracking-revenue) for more info.
 
 ## 3.6.0 (March 28, 2016)
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ out is disabled.
 
 # Tracking Revenue #
 
-The preferred method of tracking revenue for a user now is to use `logRevenueV2` in conjunction with the provided `AMPRevenue` interface. `AMPRevenue` instances will store each revenue transaction and allow you to define several special revenue properties (such as revenueType, productIdentifier, etc) that are used in Amplitude dashboard's Revenue tab. You can now also add event properties to the revenue event, via the revenueProperties field. These `AMPRevenue` instance objects are then passed into `logRevenueV2` to send as revenue events to Amplitude servers. This allows us to automatically display data relevant to revenue on the Amplitude website, including average revenue per daily active user (ARPDAU), 1, 7, 14, 30, 60, and 90 day revenue, lifetime value (LTV) estimates, and revenue by advertising campaign cohort and daily/weekly/monthly cohorts.
+The preferred method of tracking revenue for a user now is to use `logRevenueV2` in conjunction with the provided `AMPRevenue` interface. `AMPRevenue` instances will store each revenue transaction and allow you to define several special revenue properties (such as revenueType, productIdentifier, etc) that are used in Amplitude dashboard's Revenue tab. You can now also add event properties to the revenue event, via the eventProperties field. These `AMPRevenue` instance objects are then passed into `logRevenueV2` to send as revenue events to Amplitude servers. This allows us to automatically display data relevant to revenue on the Amplitude website, including average revenue per daily active user (ARPDAU), 1, 7, 14, 30, 60, and 90 day revenue, lifetime value (LTV) estimates, and revenue by advertising campaign cohort and daily/weekly/monthly cohorts.
 
 To use the `Revenue` interface, you will first need to import the class:
 ``` objective-c
@@ -248,9 +248,9 @@ AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdent
 | price              | NSNumber     | Required: the price of the products purchased (can be negative). Revenue = quantity * price                  | nil     |
 | revenueType        | NSString     | Optional: the type of revenue (ex: tax, refund, income)                                                      | nil     |
 | receipt            | NSData       | Optional: required if you want to verify the revenue event                                                   | nil     |
-| revenueProperties  | NSDictionary | Optional: a NSDictionary of event properties to include in the revenue event                                 | nil     |
+| eventProperties    | NSDictionary | Optional: a NSDictionary of event properties to include in the revenue event                                 | nil     |
 
-Note: the price can be negative, which might be useful for tracking revenue lost, for example refunds or costs.
+Note: the price can be negative, which might be useful for tracking revenue lost, for example refunds or costs. Also note, you can set event properties on the revenue event just like you would with logEvent by passing in an NSDictionary of string key value pairs. These event properties, however, will only appear in the Event Segmentation tab, not in the Revenue tab.
 
 ### Revenue Verification ###
 

--- a/README.md
+++ b/README.md
@@ -245,10 +245,12 @@ AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdent
 |--------------------|--------------|--------------------------------------------------------------------------------------------------------------|---------|--------------|
 | productId          | NSString     | Required: an identifier for the product (can be pulled from `SKPaymentTransaction.payment.productIdentifier`)| nil     | $productId   |
 | quantity           | NSInteger    | Required: the quantity of products purchased. Defaults to 1 if not specified. Revenue = quantity * price     | 1       | $quantity    |
-| price              | NSNumber     | Required: the price of the products purchased. Revenue = quantity * price                                    | nil     | $price       |
+| price              | NSNumber     | Required: the price of the products purchased (can be negative). Revenue = quantity * price                  | nil     | $price       |
 | revenueType        | NSString     | Optional: the type of revenue (ex: tax, refund, income)                                                      | nil     | $revenueType |
 | receipt            | NSData       | Optional: required if you want to verify the revenue event                                                   | nil     | $receipt     |
 | revenueProperties  | NSDictionary | Optional: a NSDictionary of event properties to include in the revenue event                                 | nil     | n/a          |
+
+Note: the price can be negative, which might be useful for tracking revenue lost, for example refunds or costs.
 
 ### Revenue Verification ###
 

--- a/README.md
+++ b/README.md
@@ -239,16 +239,16 @@ AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdent
 [[Amplitude instance] logRevenueV2:revenue];
 ```
 
-`productId`, `price`, and `quantity` are required fields. `receipt` is required if you want to verify the revenue event. Each field has a corresponding `set` method (for example `setProductId`, `setQuantity`, etc), as well as a corresponding event property key (see below for how to send revenue properties in event properties). This table describes the different fields available:
+`productId` and `price` are required fields. `quantity` defaults to 1 if not specified. `receipt` is required if you want to verify the revenue event. Each field has a corresponding `set` method (for example `setProductId`, `setQuantity`, etc). This table describes the different fields available:
 
-| Name               | Type         | Description                                                                                                  | default | property key |
-|--------------------|--------------|--------------------------------------------------------------------------------------------------------------|---------|--------------|
-| productId          | NSString     | Required: an identifier for the product (can be pulled from `SKPaymentTransaction.payment.productIdentifier`)| nil     | $productId   |
-| quantity           | NSInteger    | Required: the quantity of products purchased. Defaults to 1 if not specified. Revenue = quantity * price     | 1       | $quantity    |
-| price              | NSNumber     | Required: the price of the products purchased (can be negative). Revenue = quantity * price                  | nil     | $price       |
-| revenueType        | NSString     | Optional: the type of revenue (ex: tax, refund, income)                                                      | nil     | $revenueType |
-| receipt            | NSData       | Optional: required if you want to verify the revenue event                                                   | nil     | $receipt     |
-| revenueProperties  | NSDictionary | Optional: a NSDictionary of event properties to include in the revenue event                                 | nil     | n/a          |
+| Name               | Type         | Description                                                                                                  | default |
+|--------------------|--------------|--------------------------------------------------------------------------------------------------------------|---------|
+| productId          | NSString     | Required: an identifier for the product (can be pulled from `SKPaymentTransaction.payment.productIdentifier`)| nil     |
+| quantity           | NSInteger    | Required: the quantity of products purchased. Defaults to 1 if not specified. Revenue = quantity * price     | 1       |
+| price              | NSNumber     | Required: the price of the products purchased (can be negative). Revenue = quantity * price                  | nil     |
+| revenueType        | NSString     | Optional: the type of revenue (ex: tax, refund, income)                                                      | nil     |
+| receipt            | NSData       | Optional: required if you want to verify the revenue event                                                   | nil     |
+| revenueProperties  | NSDictionary | Optional: a NSDictionary of event properties to include in the revenue event                                 | nil     |
 
 Note: the price can be negative, which might be useful for tracking revenue lost, for example refunds or costs.
 
@@ -265,20 +265,6 @@ AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdent
 ```
 
 `receipt:` the receipt NSData from the app store. For details on how to obtain the receipt data, see [Apple's guide on Receipt Validation](https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW1).
-
-### Sending Revenue as Event Properties ###
-
-Instead of sending revenue through Amplitude's special revenue event, you can send revenue properties as event properties on any event you log. The `property key` column in the above table denotes the string key to use when declaring the event property. Note: you still need to set a productId and a price. If quantity is not set, it is assumed to be 1:
-
-``` objective-c
-NSMutableDictionary *event_properties = [NSMutableDictionary dictionary];
-[event_properties setObject:@"some event description" forKey:@"description"];
-[event_properties setObject:@"green" forKey:@"color"];
-[event_properties setObject:@"productIdentifier" forKey:@"$productId"];
-[event_properties setObject:[NSNumber numberWithDouble:10.99] forKey:@"$price"];
-[event_properties setObject:[NSNumber numberWithInt:2] forKey:@"$quantity"];
-[[Amplitude instance] logEvent:@"Completed Purchase" withEventProperties:event_properties];
-```
 
 ### Backwards compatibility ###
 


### PR DESCRIPTION
Add a new `Revenue` class that wraps revenue properties. The new class adds support for new fields like revenueType, logging event properties with revenue events, etc. Contains a little bit of logic to do some verification (like to make sure all the required fields are present). Converts into an event_properties dictionary which can be passed into logEvent