### PR TITLE
Removed extra semi-colon after function implementation.

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -310,7 +310,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         [self addObservers];
     }
     return self;
-};
+}
 
 // maintain backwards compatibility on default instance
 - (BOOL) migrateEventsDataToDB


### PR DESCRIPTION
The extra semi-colon may generate a warning on some projects.