### PR TITLE
fix crash during upgrade prefs init

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -244,7 +244,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
                 propertyListPath = [NSString stringWithFormat:@"%@_%@", propertyListPath, _instanceName]; // namespace pList with instance name
             }
             _propertyListPath = SAFE_ARC_RETAIN(propertyListPath);
-
+            _eventsDataPath = SAFE_ARC_RETAIN([eventsDataDirectory stringByAppendingPathComponent:@"com.amplitude.archiveDict"]);
             [self upgradePrefs];
 
             // Load propertyList object
@@ -277,15 +277,14 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
             // only on default instance, migrate all of old _eventsData object to database store if database just created
             if ([_instanceName isEqualToString:kAMPDefaultInstance] && oldDBVersion < kAMPDBFirstVersion) {
-                _eventsDataPath = SAFE_ARC_RETAIN([eventsDataDirectory stringByAppendingPathComponent:@"com.amplitude.archiveDict"]);
                 if ([self migrateEventsDataToDB]) {
                     // delete events data so don't need to migrate next time
                     if ([[NSFileManager defaultManager] fileExistsAtPath:_eventsDataPath]) {
                         [[NSFileManager defaultManager] removeItemAtPath:_eventsDataPath error:NULL];
                     }
                 }
-                SAFE_ARC_RELEASE(_eventsDataPath);
             }
+            SAFE_ARC_RELEASE(_eventsDataPath);
 
             // try to restore previous session
             long long previousSessionId = [self previousSessionId];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add documentation for SDK functions. You can take a look [here](https://rawgit.com/amplitude/Amplitude-iOS/master/documentation/html/index.html). A link has also been added to the Readme.
 * Updated device mapping with iPhone SE, iPad Mini 4, and iPad Pro.
+* Fix crash during upgradePrefs in the init method. This bug affected app users who were upgrading from an old version of an app using Amplitude iOS v2.1.1 or earlier straight to a version of the app using Amplitude iOS v3.6.0 or later.
 
 ## 3.7.0 (April 20, 2016)
 


### PR DESCRIPTION
`_eventsDataPath` needs to be available in `upgradePrefs`. This bug crash was introduced in v3.6.0 and affects users who are upgrading straight from v2.1.1 or older.

Fixes: https://github.com/amplitude/Amplitude-iOS/issues/102