### PR TITLE
Update revenue

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -215,7 +215,6 @@
 		E98C052F1A48E7FE00800C63 /* AmplitudeTests */ = {
 			isa = PBXGroup;
 			children = (
-				60227C0D1CC5BC07007C117B /* RevenueTests.m */,
 				60BA927D1C23768E0043178E /* AMPDatabaseHelperTests.m */,
 				9DFBB9C51AB0D1DD0017F703 /* Amplitude+Test.h */,
 				9DFBB9C61AB0D1DD0017F703 /* Amplitude+Test.m */,
@@ -226,6 +225,7 @@
 				9DDE2C021AE7069200B740EC /* DeviceInfoTests.m */,
 				60BA927E1C23768E0043178E /* IdentifyTests.m */,
 				9D40E1941AB3F6550095C7C6 /* InvalidCertificationAuthority.der */,
+				60227C0D1CC5BC07007C117B /* RevenueTests.m */,
 				9DFBB9CB1AB0D47A0017F703 /* SessionTests.m */,
 				9D82D1D71AC1006600C3F321 /* SetupTests.m */,
 				9D265EF31AB3FA2500399D93 /* SSLPinningTests.m */,

--- a/Amplitude/AMPRevenue.h
+++ b/Amplitude/AMPRevenue.h
@@ -9,7 +9,7 @@
 /**
  `AMPRevenue` objects are a wrapper for revenue data, which get passed to the `logRevenueV2` method to send to Amplitude servers.
 
- **Note:** productId and price are required fields. If quantity is not specified, then defaults to 1.
+ **Note:** price is a required field. If quantity is not specified, then defaults to 1.
 
  **Note:** Revenue amount is calculated as price * quantity.
 
@@ -32,9 +32,7 @@
  */
 
 /**
- The product identifier for the transaction.
-
- @warning: required field
+ The product identifier for the transaction (optional).
  */
 @property (nonatomic, strong, readonly) NSString *productId;
 
@@ -99,7 +97,7 @@
  */
 
 /**
- Set a value for the product identifier. This field is required for all revenue being logged.
+ Set a value for the product identifier.
 
  @param productIdentifier The value for the product identifier. Empty strings are ignored.
 

--- a/Amplitude/AMPRevenue.m
+++ b/Amplitude/AMPRevenue.m
@@ -57,10 +57,6 @@
 
 - (BOOL)isValidRevenue
 {
-    if ([AMPUtils isEmptyString:_productId]) {
-        NSLog(@"Invalid revenue, need to set productId field");
-        return NO;
-    }
     if (_price == nil) {
         NSLog(@"Invalid revenue, need to set price field");
         return NO;

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -1448,7 +1448,12 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             } else {
                 coercedKey = key;
             }
-            dict[coercedKey] = [self truncate:objCopy[key]];
+            // do not truncate revenue receipt field
+            if ([coercedKey isEqualToString:AMP_REVENUE_RECEIPT]) {
+                dict[coercedKey] = objCopy[key];
+            } else {
+                dict[coercedKey] = [self truncate:objCopy[key]];
+            }
         }
         SAFE_ARC_RELEASE(objCopy);
         obj = [NSDictionary dictionaryWithDictionary:dict];

--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -520,6 +520,7 @@
     [object setValue:[NSNumber numberWithBool:NO] forKey:@"bool value"];
     [object setValue:longString forKey:@"long string"];
     [object setValue:[NSArray arrayWithObject:longString] forKey:@"array"];
+    [object setValue:longString forKey:AMP_REVENUE_RECEIPT];
 
     object = [self.amplitude truncate:object];
     XCTAssertEqual([[object objectForKey:@"int value"] intValue], 10);
@@ -528,6 +529,9 @@
     XCTAssertEqual([[object objectForKey:@"array"] count], 1);
     XCTAssertEqualObjects([object objectForKey:@"array"][0], truncString);
     XCTAssertEqual([[object objectForKey:@"array"][0] length], kAMPMaxStringLength);
+
+    // receipt field should not be truncated
+    XCTAssertEqualObjects([object objectForKey:AMP_REVENUE_RECEIPT], longString);
 }
 
 -(void)testTruncateEventAndIdentify {

--- a/AmplitudeTests/RevenueTests.m
+++ b/AmplitudeTests/RevenueTests.m
@@ -116,7 +116,7 @@
     XCTAssertFalse([revenue2 isValidRevenue]);
     [revenue2 setPrice:[NSNumber numberWithDouble:10.99]];
     [revenue2 setQuantity:10];
-    XCTAssertFalse([revenue2 isValidRevenue]);
+    XCTAssertTrue([revenue2 isValidRevenue]);
     [revenue2 setProductIdentifier:@"testProductId"];
     XCTAssertTrue([revenue2 isValidRevenue]);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* `productId` is no longer a required field for `Revenue` logged via `logRevenueV2`.
+
 ## 3.8.1 (June 14, 2016)
 
 * Allow ability to silence error messages. Note error messages are printed by default. To disable error logging, change `AMPLITUDE_LOG_ERRORS` from `1` to `0` in `Amplitude.m`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * `productId` is no longer a required field for `Revenue` logged via `logRevenueV2`.
+* Fix bug where revenue receipt was being truncated if it was too long (exceeded 1024 characters);
 
 ## 3.8.1 (June 14, 2016)
 

--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ AMPRevenue *revenue = [[[AMPRevenue revenue] setProductIdentifier:@"productIdent
 [[Amplitude instance] logRevenueV2:revenue];
 ```
 
-`productId` and `price` are required fields. `quantity` defaults to 1 if not specified. `receipt` is required if you want to verify the revenue event. Each field has a corresponding `set` method (for example `setProductId`, `setQuantity`, etc). This table describes the different fields available:
+`price` is a required field. `quantity` defaults to 1 if not specified. `receipt` is required if you want to verify the revenue event. Each field has a corresponding `set` method (for example `setProductId`, `setQuantity`, etc). This table describes the different fields available:
 
 | Name               | Type         | Description                                                                                                  | default |
 |--------------------|--------------|--------------------------------------------------------------------------------------------------------------|---------|
-| productId          | NSString     | Required: an identifier for the product (can be pulled from `SKPaymentTransaction.payment.productIdentifier`)| nil     |
+| productId          | NSString     | Optional: an identifier for the product (can be pulled from `SKPaymentTransaction.payment.productIdentifier`)| nil     |
 | quantity           | NSInteger    | Required: the quantity of products purchased. Defaults to 1 if not specified. Revenue = quantity * price     | 1       |
 | price              | NSNumber     | Required: the price of the products purchased (can be negative). Revenue = quantity * price                  | nil     |
 | revenueType        | NSString     | Optional: the type of revenue (ex: tax, refund, income)                                                      | nil     |


### PR DESCRIPTION
* productId is no longer a required field. This is required to update Segment iOS SDK to use logRevenueV2 since it assumes productId can be null
* Do not truncate receipt and receipt sig fields even if they exceed 1024 characters
* need to regenerate docs before releasing new version

This mirrors the revenue update for Android SDK