### PR TITLE
fix 32 bit overflow

### DIFF
--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -419,7 +419,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         if ([table isEqualToString:STORE_TABLE_NAME]) {
             success &= sqlite3_bind_text(stmt, 2, [(NSString *)value UTF8String], -1, SQLITE_STATIC) == SQLITE_OK;
         } else {
-            success &= sqlite3_bind_int64(stmt, 2, [(NSNumber*)value integerValue]) == SQLITE_OK;
+            success &= sqlite3_bind_int64(stmt, 2, [(NSNumber*)value longLongValue]) == SQLITE_OK;
         }
 
         if (!success) {

--- a/AmplitudeTests/AMPDatabaseHelperTests.m
+++ b/AmplitudeTests/AMPDatabaseHelperTests.m
@@ -454,4 +454,17 @@
     XCTAssertTrue([self.databaseHelper addIdentify:@"test"]);
 }
 
+- (void)testInsertAndReplaceKeyLargeLongValue {
+    NSString *key = @"test_key";
+    NSNumber *value1 = [NSNumber numberWithLongLong:214748364700000LL];
+    NSNumber *value2 = [NSNumber numberWithLongLong:2147483647000000LL];
+    XCTAssertNil([self.databaseHelper getLongValue:key]);
+
+    [self.databaseHelper insertOrReplaceKeyLongValue:key value:value1];
+    XCTAssert([[self.databaseHelper getLongValue:key] isEqualToNumber:value1]);
+
+    [self.databaseHelper insertOrReplaceKeyLongValue:key value:value2];
+    XCTAssert([[self.databaseHelper getLongValue:key] isEqualToNumber:value2]);
+}
+
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix overflow bug for long long values saved to Sqlite DB on 32-bit devices.
+
 ### 3.8.2 (July 11, 2016)
 
 * `productId` is no longer a required field for `Revenue` logged via `logRevenueV2`.


### PR DESCRIPTION
Casting the long long NSNumber to NSInteger caused overflow, since NSInteger size depends on the platform, in the case of iPhone 5C and earlier, it's 32-bit. We should instead be using the long long value