### PR TITLE
remove initializerQueue, move db logic from init to initializeApiKey,…

### DIFF
--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -73,12 +73,12 @@
 
 - (void)testInitWithInstanceName {
     Amplitude *a = [Amplitude instanceWithName:@"APP1"];
-    [a flushQueueWithQueue:a.initializerQueue];
+    [a flushQueue];
     XCTAssertEqualObjects(a.instanceName, @"app1");
     XCTAssertTrue([a.propertyListPath rangeOfString:@"com.amplitude.plist_app1"].location != NSNotFound);
 
     Amplitude *b = [Amplitude instanceWithName:[kAMPDefaultInstance uppercaseString]];
-    [b flushQueueWithQueue:b.initializerQueue];
+    [b flushQueue];
     XCTAssertEqualObjects(b.instanceName, kAMPDefaultInstance);
     XCTAssertTrue([b.propertyListPath rangeOfString:@"com.amplitude.plist"].location != NSNotFound);
     XCTAssertTrue([ b.propertyListPath rangeOfString:@"com.amplitude.plist_"].location == NSNotFound);
@@ -110,6 +110,8 @@
     [newDBHelper2 resetDB:NO];
 
     // setup existing database file, init default instance
+    [[Amplitude instance] initializeApiKey:apiKey];
+    [[Amplitude instance] flushQueue];
     [oldDbHelper insertOrReplaceKeyLongValue:@"sequence_number" value:[NSNumber numberWithLongLong:1000]];
     [oldDbHelper addEvent:@"{\"event_type\":\"oldEvent\"}"];
     [oldDbHelper addIdentify:@"{\"event_type\":\"$identify\"}"];

--- a/AmplitudeTests/BaseTestCase.m
+++ b/AmplitudeTests/BaseTestCase.m
@@ -30,12 +30,12 @@ NSString *const userId = @"userId";
     XCTAssertTrue([self.databaseHelper resetDB:NO]);
 
     [self.amplitude init];
+    [self.amplitude flushQueue];
     self.amplitude.sslPinningEnabled = NO;
 }
 
 - (void)tearDown {
     // Ensure all background operations are done
-    [self.amplitude flushQueueWithQueue:self.amplitude.initializerQueue];
     [self.amplitude flushQueue];
     SAFE_ARC_RELEASE(_amplitude);
     SAFE_ARC_RELEASE(_databaseHelper);

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -42,7 +42,6 @@
     id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
     [[mockAmplitude reject] enterForeground];
     [mockAmplitude initializeApiKey:apiKey];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
     [mockAmplitude verify];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
@@ -56,7 +55,6 @@
     id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
     [[mockAmplitude expect] enterForeground];
     [mockAmplitude initializeApiKey:apiKey];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
     [mockAmplitude verify];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
@@ -70,7 +68,6 @@
     [[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date)] currentTime];
 
     [mockAmplitude initializeApiKey:apiKey userId:nil];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
     XCTAssertEqual([mockAmplitude sessionId], 1000000);
@@ -140,7 +137,7 @@
 
 - (void)testEnterBackgroundDoesNotTrackEvent {
     [self.amplitude initializeApiKey:apiKey userId:nil];
-    [self.amplitude flushQueueWithQueue:self.amplitude.initializerQueue];
+    [self.amplitude flushQueue];
 
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil userInfo:nil];
@@ -156,7 +153,6 @@
     [mockAmplitude setTrackingSessionEvents:YES];
 
     [mockAmplitude initializeApiKey:apiKey userId:nil];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
@@ -192,7 +188,6 @@
     [mockAmplitude setTrackingSessionEvents:YES];
 
     [mockAmplitude initializeApiKey:apiKey userId:nil];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Migrate all database logic from `init` to `initializeApiKey`.
+* Run `init` logic on `backgroundQueue`, removing need for separate `initializerQueue`.
+
 ### 3.8.3 (July 18, 2016)
 
 * Fix overflow bug for long long values saved to Sqlite DB on 32-bit devices.


### PR DESCRIPTION
… guarded db interactions with apikey check

This is part 1 of the database migration work. We need to migrate any database interaction logic in the `init` method into the `initializeApiKey` method since we will need the apiKey to interact with the database. I also run the `init` logic on the `backgroundQueue`, removing the need for a separate `initializerQueue`.

Few things to note:
* `_dbHelper` is initialized in `initializeApiKey` now. Any public methods that interact with the database such as `setUserId`, `setDeviceId`, `identify`, etc need to be guarded with an apiKey check to ensure `[self.dbHelper]` is available
* I moved `[self addObservers]` to `initializeApiKey` since `enterBackground` interacts with the DB by saving the current timestamp.
* Most tests still pass. Just need to flush the background queue instead of the initializerQueue.
* Reran all tests on iPhone 4, iPhone 5, iPhone 6S Plus, tested demo app on test device