### PR TITLE
Rename db file

### DIFF
--- a/Amplitude/AMPDatabaseHelper.h
+++ b/Amplitude/AMPDatabaseHelper.h
@@ -10,8 +10,7 @@
 
 @property (nonatomic, strong, readonly) NSString *databasePath;
 
-+ (AMPDatabaseHelper*)getDatabaseHelper;
-+ (AMPDatabaseHelper*)getDatabaseHelper:(NSString*) instanceName;
++ (AMPDatabaseHelper*)getDatabaseHelper:(NSString*) instanceName apiKey:(NSString*) apiKey;
 - (BOOL)createTables;
 - (BOOL)dropTables;
 - (BOOL)upgrade:(int) oldVersion newVersion:(int) newVersion;

--- a/Amplitude/AMPDatabaseHelper.h
+++ b/Amplitude/AMPDatabaseHelper.h
@@ -11,6 +11,7 @@
 @property (nonatomic, strong, readonly) NSString *databasePath;
 
 + (AMPDatabaseHelper*)getDatabaseHelper:(NSString*) instanceName apiKey:(NSString*) apiKey;
++ (AMPDatabaseHelper*)getDatabaseHelperWithInstanceName:(NSString*) instanceName; // for testing only
 - (BOOL)createTables;
 - (BOOL)dropTables;
 - (BOOL)upgrade:(int) oldVersion newVersion:(int) newVersion;

--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -31,7 +31,6 @@
 
 @implementation AMPDatabaseHelper
 {
-    BOOL _databaseCreated;
     sqlite3 *_database;
     dispatch_queue_t _queue;
 }
@@ -95,6 +94,13 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return dbHelper;
 }
 
+// for testing only
++ (AMPDatabaseHelper*)getDatabaseHelperWithInstanceName:(NSString*) instanceName
+{
+    AMPDatabaseHelper *dbHelper = [[AMPDatabaseHelper alloc] initWithInstanceName:instanceName andApiKey:nil];
+    return SAFE_ARC_AUTORELEASE(dbHelper);
+}
+
 // instanceName should not be null, getDatabaseHelper will guard
 // apiKey should only be null for testing - Amplitude client will guard
 - (id)initWithInstanceName:(NSString*) instanceName andApiKey:(NSString*) apiKey
@@ -107,11 +113,11 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         }
 
         // migrate to new db filename
-//        if (![AMPUtils isEmptyString:apiKey]) {
-//            NSString *newDatabasePath = [NSString stringWithFormat:@"%@_%@", databasePath, apiKey];
-////            [AMPUtils moveFileIfNotExists:databasePath to:newDatabasePath];
-////            databasePath = newDatabasePath;
-//        }
+        if (![AMPUtils isEmptyString:apiKey]) {
+            NSString *newDatabasePath = [NSString stringWithFormat:@"%@_%@", databasePath, apiKey];
+            [AMPUtils moveFileIfNotExists:databasePath to:newDatabasePath];
+            databasePath = newDatabasePath;
+        }
 
         _databasePath = SAFE_ARC_RETAIN(databasePath);
         _queue = dispatch_queue_create([QUEUE_NAME UTF8String], NULL);

--- a/Amplitude/AMPUtils.h
+++ b/Amplitude/AMPUtils.h
@@ -12,5 +12,6 @@
 + (id) makeJSONSerializable:(id) obj;
 + (BOOL) isEmptyString:(NSString*) str;
 + (NSDictionary*) validateGroups:(NSDictionary*) obj;
++ (BOOL)moveFileIfNotExists:(NSString*)from to:(NSString*)to;
 
 @end

--- a/Amplitude/AMPUtils.m
+++ b/Amplitude/AMPUtils.m
@@ -141,4 +141,21 @@
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
++ (BOOL)moveFileIfNotExists:(NSString*)from to:(NSString*)to
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error;
+    if (![fileManager fileExistsAtPath:to] &&
+        [fileManager fileExistsAtPath:from]) {
+        if ([fileManager copyItemAtPath:from toPath:to error:&error]) {
+            AMPLITUDE_LOG(@"INFO: copied %@ to %@", from, to);
+            [fileManager removeItemAtPath:from error:NULL];
+        } else {
+            AMPLITUDE_LOG(@"WARN: Copy from %@ to %@ failed: %@", from, to, error);
+            return NO;
+        }
+    }
+    return YES;
+}
+
 @end

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -288,7 +288,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         return NO;
     }
 
-    AMPDatabaseHelper *defaultDbHelper = [AMPDatabaseHelper getDatabaseHelper];
+    AMPDatabaseHelper *defaultDbHelper = [AMPDatabaseHelper getDatabaseHelper:nil apiKey:_apiKey];
     BOOL success = YES;
 
     // migrate events
@@ -421,7 +421,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         SAFE_ARC_RETAIN(apiKey);
         SAFE_ARC_RELEASE(_apiKey);
         _apiKey = apiKey;
-        _dbHelper = SAFE_ARC_RETAIN([AMPDatabaseHelper getDatabaseHelper:_instanceName]);
+        _dbHelper = SAFE_ARC_RETAIN([AMPDatabaseHelper getDatabaseHelper:_instanceName apiKey:_apiKey]);
 
         [self runOnBackgroundQueue:^{
             // update database if necessary
@@ -1563,8 +1563,8 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     NSString *oldEventsDataDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
     NSString *oldPropertyListPath = [oldEventsDataDirectory stringByAppendingPathComponent:@"com.amplitude.plist"];
     NSString *oldEventsDataPath = [oldEventsDataDirectory stringByAppendingPathComponent:@"com.amplitude.archiveDict"];
-    BOOL success = [self moveFileIfNotExists:oldPropertyListPath to:_propertyListPath];
-    success &= [self moveFileIfNotExists:oldEventsDataPath to:_eventsDataPath];
+    BOOL success = [AMPUtils moveFileIfNotExists:oldPropertyListPath to:_propertyListPath];
+    success &= [AMPUtils moveFileIfNotExists:oldEventsDataPath to:_eventsDataPath];
     return success;
 }
 
@@ -1647,23 +1647,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (BOOL)archive:(id) obj toFile:(NSString*)path {
     return [NSKeyedArchiver archiveRootObject:obj toFile:path];
-}
-
-- (BOOL)moveFileIfNotExists:(NSString*)from to:(NSString*)to
-{
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSError *error;
-    if (![fileManager fileExistsAtPath:to] &&
-        [fileManager fileExistsAtPath:from]) {
-        if ([fileManager copyItemAtPath:from toPath:to error:&error]) {
-            AMPLITUDE_LOG(@"INFO: copied %@ to %@", from, to);
-            [fileManager removeItemAtPath:from error:NULL];
-        } else {
-            AMPLITUDE_LOG(@"WARN: Copy from %@ to %@ failed: %@", from, to, error);
-            return NO;
-        }
-    }
-    return YES;
 }
 
 #pragma clang diagnostic pop

--- a/AmplitudeTests/AMPDatabaseHelperTests.m
+++ b/AmplitudeTests/AMPDatabaseHelperTests.m
@@ -17,9 +17,15 @@
 
 @implementation AMPDatabaseHelperTests {}
 
+
+NSString *const testApiKey = @"000000";
+NSString *const apiKey1 = @"111111";
+NSString *const apiKey2 = @"222222";
+
+
 - (void)setUp {
     [super setUp];
-    self.databaseHelper = [AMPDatabaseHelper getDatabaseHelper];
+    self.databaseHelper = [AMPDatabaseHelper getDatabaseHelper:nil apiKey:testApiKey];
     [self.databaseHelper resetDB:NO];
 }
 
@@ -31,23 +37,22 @@
 
 - (void)testGetDatabaseHelper {
     // test backwards compatibility on default instance
-    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
-    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:nil]);
-    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:@""]);
-    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:kAMPDefaultInstance]);
+    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper:nil apiKey:testApiKey];
+    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:@"" apiKey:testApiKey]);
+    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:kAMPDefaultInstance apiKey:testApiKey]);
 
-    AMPDatabaseHelper *a = [AMPDatabaseHelper getDatabaseHelper:@"a"];
-    AMPDatabaseHelper *b = [AMPDatabaseHelper getDatabaseHelper:@"b"];
+    AMPDatabaseHelper *a = [AMPDatabaseHelper getDatabaseHelper:@"a" apiKey:apiKey1];
+    AMPDatabaseHelper *b = [AMPDatabaseHelper getDatabaseHelper:@"b" apiKey:apiKey2];
     XCTAssertNotEqual(dbHelper, a);
     XCTAssertNotEqual(dbHelper, b);
     XCTAssertNotEqual(a, b);
-    XCTAssertEqual(a, [AMPDatabaseHelper getDatabaseHelper:@"a"]);
-    XCTAssertEqual(b, [AMPDatabaseHelper getDatabaseHelper:@"b"]);
+    XCTAssertEqual(a, [AMPDatabaseHelper getDatabaseHelper:@"a" apiKey:apiKey1]);
+    XCTAssertEqual(b, [AMPDatabaseHelper getDatabaseHelper:@"b" apiKey:apiKey2]);
 
     // test case insensitive instance name
-    XCTAssertEqual(a, [AMPDatabaseHelper getDatabaseHelper:@"A"]);
-    XCTAssertEqual(b, [AMPDatabaseHelper getDatabaseHelper:@"B"]);
-    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:[kAMPDefaultInstance uppercaseString]]);
+    XCTAssertEqual(a, [AMPDatabaseHelper getDatabaseHelper:@"A" apiKey:apiKey1]);
+    XCTAssertEqual(b, [AMPDatabaseHelper getDatabaseHelper:@"B" apiKey:apiKey2]);
+    XCTAssertEqual(dbHelper, [AMPDatabaseHelper getDatabaseHelper:[kAMPDefaultInstance uppercaseString] apiKey:testApiKey]);
 
     // test each instance maintains separate database files
     XCTAssertTrue([a.databasePath rangeOfString:@"com.amplitude.database_a"].location != NSNotFound);
@@ -60,9 +65,9 @@
 }
 
 - (void)testSeparateInstances {
-    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
-    AMPDatabaseHelper *a = [AMPDatabaseHelper getDatabaseHelper:@"a"];
-    AMPDatabaseHelper *b = [AMPDatabaseHelper getDatabaseHelper:@"b"];
+    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper:nil apiKey:testApiKey];
+    AMPDatabaseHelper *a = [AMPDatabaseHelper getDatabaseHelper:@"a" apiKey:apiKey1];
+    AMPDatabaseHelper *b = [AMPDatabaseHelper getDatabaseHelper:@"b" apiKey:apiKey2];
 
     [a resetDB:NO];
     [b resetDB:NO];

--- a/AmplitudeTests/Amplitude+Test.m
+++ b/AmplitudeTests/Amplitude+Test.m
@@ -19,6 +19,8 @@
 @dynamic sessionId;
 @dynamic lastEventTime;
 
+NSString *const newTestApiKey = @"000000";
+
 - (void)flushQueue {
     [self flushQueueWithQueue:[self backgroundQueue]];
 }
@@ -28,22 +30,22 @@
 }
 
 - (NSDictionary *)getEvent:(NSInteger) fromEnd {
-    NSArray *events = [[AMPDatabaseHelper getDatabaseHelper] getEvents:-1 limit:-1];
+    NSArray *events = [[AMPDatabaseHelper getDatabaseHelper:nil apiKey:newTestApiKey] getEvents:-1 limit:-1];
     return [events objectAtIndex:[events count] - fromEnd - 1];
 }
 
 - (NSDictionary *)getLastEvent {
-    NSArray *events = [[AMPDatabaseHelper getDatabaseHelper] getEvents:-1 limit:-1];
+    NSArray *events = [[AMPDatabaseHelper getDatabaseHelper:nil apiKey:newTestApiKey] getEvents:-1 limit:-1];
     return [events lastObject];
 }
 
 - (NSDictionary *)getLastIdentify {
-    NSArray *identifys = [[AMPDatabaseHelper getDatabaseHelper] getIdentifys:-1 limit:-1];
+    NSArray *identifys = [[AMPDatabaseHelper getDatabaseHelper:nil apiKey:newTestApiKey] getIdentifys:-1 limit:-1];
     return [identifys lastObject];
 }
 
 - (NSUInteger)queuedEventCount {
-    return [[AMPDatabaseHelper getDatabaseHelper] getEventCount];
+    return [[AMPDatabaseHelper getDatabaseHelper:nil apiKey:newTestApiKey] getEventCount];
 }
 
 - (void)flushUploads:(void (^)())handler {

--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -73,12 +73,12 @@
 
 - (void)testInitWithInstanceName {
     Amplitude *a = [Amplitude instanceWithName:@"APP1"];
-    [a flushQueueWithQueue:a.initializerQueue];
+    [a flushQueue];
     XCTAssertEqualObjects(a.instanceName, @"app1");
     XCTAssertTrue([a.propertyListPath rangeOfString:@"com.amplitude.plist_app1"].location != NSNotFound);
 
     Amplitude *b = [Amplitude instanceWithName:[kAMPDefaultInstance uppercaseString]];
-    [b flushQueueWithQueue:b.initializerQueue];
+    [b flushQueue];
     XCTAssertEqualObjects(b.instanceName, kAMPDefaultInstance);
     XCTAssertTrue([b.propertyListPath rangeOfString:@"com.amplitude.plist"].location != NSNotFound);
     XCTAssertTrue([ b.propertyListPath rangeOfString:@"com.amplitude.plist_"].location == NSNotFound);
@@ -110,6 +110,8 @@
     [newDBHelper2 resetDB:NO];
 
     // setup existing database file, init default instance
+    [[Amplitude instance] initializeApiKey:apiKey];
+    [[Amplitude instance] flushQueue];
     [oldDbHelper insertOrReplaceKeyLongValue:@"sequence_number" value:[NSNumber numberWithLongLong:1000]];
     [oldDbHelper addEvent:@"{\"event_type\":\"oldEvent\"}"];
     [oldDbHelper addIdentify:@"{\"event_type\":\"$identify\"}"];

--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -226,6 +226,25 @@
     XCTAssertEqual([self.amplitude userId], nil);
 }
 
+- (void)testDatabaseScopeMigration {
+    NSString *migrationInstanceName = @"testMigrationInstance";
+    NSString *migrationApiKey = @"testMigrationInstanceApiKey";
+    NSString *deviceId = @"testMigrationDeviceId";
+
+    // create old database file
+    AMPDatabaseHelper *oldDbHelper = [AMPDatabaseHelper getDatabaseHelperWithInstanceName:migrationInstanceName];
+    [oldDbHelper insertOrReplaceKeyValue:@"device_id" value:deviceId];
+
+    // init new client, verify migration
+    Amplitude *client = [Amplitude instanceWithName:migrationInstanceName];
+    [client initializeApiKey:migrationApiKey];
+    [client flushQueue];
+    XCTAssertEqualObjects([client getDeviceId], deviceId);
+
+    AMPDatabaseHelper *newDbHelper = [AMPDatabaseHelper getDatabaseHelper:migrationInstanceName apiKey:migrationApiKey];
+    XCTAssertEqualObjects([newDbHelper getValue:@"device_id"], deviceId);
+}
+
 - (void)testClearUserId {
     [self.amplitude flushQueue];
     XCTAssertEqual([self.amplitude userId], nil);

--- a/AmplitudeTests/BaseTestCase.m
+++ b/AmplitudeTests/BaseTestCase.m
@@ -26,7 +26,7 @@ NSString *const userId = @"userId";
 - (void)setUp {
     [super setUp];
     self.amplitude = [Amplitude alloc];
-    self.databaseHelper = [AMPDatabaseHelper getDatabaseHelper];
+    self.databaseHelper = [AMPDatabaseHelper getDatabaseHelper:nil apiKey:apiKey];
     XCTAssertTrue([self.databaseHelper resetDB:NO]);
 
     [self.amplitude init];

--- a/AmplitudeTests/BaseTestCase.m
+++ b/AmplitudeTests/BaseTestCase.m
@@ -30,12 +30,12 @@ NSString *const userId = @"userId";
     XCTAssertTrue([self.databaseHelper resetDB:NO]);
 
     [self.amplitude init];
+    [self.amplitude flushQueue];
     self.amplitude.sslPinningEnabled = NO;
 }
 
 - (void)tearDown {
     // Ensure all background operations are done
-    [self.amplitude flushQueueWithQueue:self.amplitude.initializerQueue];
     [self.amplitude flushQueue];
     SAFE_ARC_RELEASE(_amplitude);
     SAFE_ARC_RELEASE(_databaseHelper);

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -215,18 +215,16 @@
 }
 
 - (void)testSkipSessionCheckWhenLoggingSessionEvents {
-    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
-
     NSDate *date = [NSDate dateWithTimeIntervalSince1970:1000];
     NSNumber *timestamp = [NSNumber numberWithLongLong:[date timeIntervalSince1970] * 1000];
-    [dbHelper insertOrReplaceKeyLongValue:@"previous_session_id" value:timestamp];
+    [self.databaseHelper insertOrReplaceKeyLongValue:@"previous_session_id" value:timestamp];
 
     self.amplitude.trackingSessionEvents = YES;
     [self.amplitude initializeApiKey:apiKey userId:nil];
 
     [self.amplitude flushQueue];
-    XCTAssertEqual([dbHelper getEventCount], 2);
-    NSArray *events = [dbHelper getEvents:-1 limit:2];
+    XCTAssertEqual([self.databaseHelper getEventCount], 2);
+    NSArray *events = [self.databaseHelper getEvents:-1 limit:2];
     XCTAssertEqualObjects(events[0][@"event_type"], kAMPSessionEndEvent);
     XCTAssertEqualObjects(events[1][@"event_type"], kAMPSessionStartEvent);
 }

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -42,7 +42,6 @@
     id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
     [[mockAmplitude reject] enterForeground];
     [mockAmplitude initializeApiKey:apiKey];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
     [mockAmplitude verify];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
@@ -56,7 +55,6 @@
     id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
     [[mockAmplitude expect] enterForeground];
     [mockAmplitude initializeApiKey:apiKey];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
     [mockAmplitude verify];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
@@ -70,7 +68,6 @@
     [[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date)] currentTime];
 
     [mockAmplitude initializeApiKey:apiKey userId:nil];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
     XCTAssertEqual([mockAmplitude sessionId], 1000000);
@@ -140,7 +137,7 @@
 
 - (void)testEnterBackgroundDoesNotTrackEvent {
     [self.amplitude initializeApiKey:apiKey userId:nil];
-    [self.amplitude flushQueueWithQueue:self.amplitude.initializerQueue];
+    [self.amplitude flushQueue];
 
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil userInfo:nil];
@@ -156,7 +153,6 @@
     [mockAmplitude setTrackingSessionEvents:YES];
 
     [mockAmplitude initializeApiKey:apiKey userId:nil];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
@@ -192,7 +188,6 @@
     [mockAmplitude setTrackingSessionEvents:YES];
 
     [mockAmplitude initializeApiKey:apiKey userId:nil];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);

--- a/AmplitudeTests/SetupTests.m
+++ b/AmplitudeTests/SetupTests.m
@@ -79,8 +79,7 @@
 
 - (void)testUserPropertiesSet {
     [self.amplitude initializeApiKey:apiKey];
-    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
-    XCTAssertEqual([dbHelper getEventCount], 0);
+    XCTAssertEqual([self.databaseHelper getEventCount], 0);
 
     NSDictionary *properties = @{
          @"shoeSize": @10,
@@ -90,9 +89,9 @@
 
     [self.amplitude setUserProperties:properties];
     [self.amplitude flushQueue];
-    XCTAssertEqual([dbHelper getEventCount], 0);
-    XCTAssertEqual([dbHelper getIdentifyCount], 1);
-    XCTAssertEqual([dbHelper getTotalEventCount], 1);
+    XCTAssertEqual([self.databaseHelper getEventCount], 0);
+    XCTAssertEqual([self.databaseHelper getIdentifyCount], 1);
+    XCTAssertEqual([self.databaseHelper getTotalEventCount], 1);
 
     NSDictionary *expected = [NSDictionary dictionaryWithObject:properties forKey:AMP_OP_SET];
 
@@ -104,42 +103,40 @@
 }
 
 - (void)testSetDeviceId {
-    AMPDatabaseHelper *dbHelper = [AMPDatabaseHelper getDatabaseHelper];
-
     [self.amplitude initializeApiKey:apiKey];
     [self.amplitude flushQueue];
     NSString *generatedDeviceId = [self.amplitude getDeviceId];
     XCTAssertNotNil(generatedDeviceId);
     XCTAssertEqual(generatedDeviceId.length, 36);
-    XCTAssertEqualObjects([dbHelper getValue:@"device_id"], generatedDeviceId);
+    XCTAssertEqualObjects([self.databaseHelper getValue:@"device_id"], generatedDeviceId);
 
     // test setting invalid device ids
     [self.amplitude setDeviceId:nil];
     [self.amplitude flushQueue];
     XCTAssertEqualObjects([self.amplitude getDeviceId], generatedDeviceId);
-    XCTAssertEqualObjects([dbHelper getValue:@"device_id"], generatedDeviceId);
+    XCTAssertEqualObjects([self.databaseHelper getValue:@"device_id"], generatedDeviceId);
 
     id dict = [NSDictionary dictionary];
     [self.amplitude setDeviceId:dict];
     [self.amplitude flushQueue];
     XCTAssertEqualObjects([self.amplitude getDeviceId], generatedDeviceId);
-    XCTAssertEqualObjects([dbHelper getValue:@"device_id"], generatedDeviceId);
+    XCTAssertEqualObjects([self.databaseHelper getValue:@"device_id"], generatedDeviceId);
 
     [self.amplitude setDeviceId:@"e3f5536a141811db40efd6400f1d0a4e"];
     [self.amplitude flushQueue];
     XCTAssertEqualObjects([self.amplitude getDeviceId], generatedDeviceId);
-    XCTAssertEqualObjects([dbHelper getValue:@"device_id"], generatedDeviceId);
+    XCTAssertEqualObjects([self.databaseHelper getValue:@"device_id"], generatedDeviceId);
 
     [self.amplitude setDeviceId:@"04bab7ee75b9a58d39b8dc54e8851084"];
     [self.amplitude flushQueue];
     XCTAssertEqualObjects([self.amplitude getDeviceId], generatedDeviceId);
-    XCTAssertEqualObjects([dbHelper getValue:@"device_id"], generatedDeviceId);
+    XCTAssertEqualObjects([self.databaseHelper getValue:@"device_id"], generatedDeviceId);
 
     NSString *validDeviceId = [AMPUtils generateUUID];
     [self.amplitude setDeviceId:validDeviceId];
     [self.amplitude flushQueue];
     XCTAssertEqualObjects([self.amplitude getDeviceId], validDeviceId);
-    XCTAssertEqualObjects([dbHelper getValue:@"device_id"], validDeviceId);
+    XCTAssertEqualObjects([self.databaseHelper getValue:@"device_id"], validDeviceId);
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Migrate all database logic from `init` to `initializeApiKey`.
+* Run `init` logic on `backgroundQueue`, removing need for separate `initializerQueue`.
+
 ### 3.8.3 (July 18, 2016)
 
 * Fix overflow bug for long long values saved to Sqlite DB on 32-bit devices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Migrate Sqlite database file to new filename with apiKey.
 * Migrate all database logic from `init` to `initializeApiKey`.
 * Run `init` logic on `backgroundQueue`, removing need for separate `initializerQueue`.
 


### PR DESCRIPTION
This mirrors the db file renaming work done on Android: https://github.com/amplitude/Amplitude-Android/pull/112/files

Tested the renaming on demo app on both simulator and real test device. Also tested that subsequent re-opening of app skips the renaming. Tested that all the database data was still intact (previous sessionId, last event time, deviceId, event id, etc). Added two unit tests as well.

A lot of the test updates is just fixing the call to `getDatabaseHelper`. I added a new extra method `getDatabaseHelperWithInstanceName` just for testing, explicitly with a new name so that any uncaught calls to the old `getDatabaseHelper:instanceName` would not erroneously get mapped to the test method. The purpose of the test method is to re-generate the old database file, sidestepping the static _instances which I cannot access directly.

We already have a helper method to move files around, so I just factored it out into AMPUtils.

Note: the new database filename is in the form `com.amplitude.database_instancename_apiKey`. I was a little worried that the filename might become too long. iOS limits the full file path to 1024 chars, and the actual filename to 255 chars. On the actual test device, the full path looks like this: `/var/mobile/Containers/Data/Application/85A9D80F-FA07-456F-A1CB-BD4C54145649/Library/com.amplitude.database_app2_c6fa6b27f515fb3f0e5ece6caf86027b`, which is only 145 characters. So I think it's safe to use that format for the new name.


This builds on top of https://github.com/amplitude/Amplitude-iOS/pull/109. Comments from that PR:
We need to migrate any database interaction logic in the `init` method into the `initializeApiKey` method since we will need the apiKey to interact with the database. I also run the `init` logic on the `backgroundQueue`, removing the need for a separate `initializerQueue`.

Few things to note:
* `_dbHelper` is initialized in `initializeApiKey` now. Any public methods that interact with the database such as `setUserId`, `setDeviceId`, `identify`, etc need to be guarded with an apiKey check to ensure `[self.dbHelper]` is available
* I moved `[self addObservers]` to `initializeApiKey` since `enterBackground` interacts with the DB by saving the current timestamp.
* Most tests still pass. Just need to flush the background queue instead of the initializerQueue.
* Reran all tests on iPhone 4, iPhone 5, iPhone 6S Plus, tested demo app on test device
