### PR TITLE
handle null event strings

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -339,18 +339,16 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     for (id event in events) {
         NSError *error = nil;
         NSData *jsonData = nil;
-        @try {
-            jsonData = [NSJSONSerialization dataWithJSONObject:[AMPUtils makeJSONSerializable:event] options:0 error:&error];
-        }
-        @catch (NSException *exception) {
-            AMPLITUDE_ERROR(@"ERROR: NSJSONSerialization error: %@", exception.reason);
-            continue;
-        }
+        jsonData = [NSJSONSerialization dataWithJSONObject:[AMPUtils makeJSONSerializable:event] options:0 error:&error];
         if (error != nil) {
             AMPLITUDE_ERROR(@"ERROR: NSJSONSerialization error: %@", error);
             continue;
         }
         NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        if ([AMPUtils isEmptyString:jsonString]) {
+            AMPLITUDE_ERROR(@"ERROR: NSJSONSerialization resulted in a null string, skipping this event");
+            continue;
+        }
         success &= [defaultDbHelper addEvent:jsonString];
         SAFE_ARC_RELEASE(jsonString);
     }
@@ -601,8 +599,17 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         [self annotateEvent:event];
 
         // convert event dictionary to JSON String
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[AMPUtils makeJSONSerializable:event] options:0 error:NULL];
+        NSError *error = nil;
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[AMPUtils makeJSONSerializable:event] options:0 error:&error];
+        if (error != nil) {
+            AMPLITUDE_ERROR(@"ERROR: could not JSONSerialize event type %@: %@", eventType, error);
+            return;
+        }
         NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        if ([AMPUtils isEmptyString:jsonString]) {
+            AMPLITUDE_ERROR(@"ERROR: JSONSerializing event type %@ resulted in an NULL string", eventType);
+            return;
+        }
         if ([eventType isEqualToString:IDENTIFY_EVENT]) {
             (void) [self.dbHelper addIdentify:jsonString];
         } else {
@@ -809,24 +816,22 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
         NSError *error = nil;
         NSData *eventsDataLocal = nil;
-        @try {
-            eventsDataLocal = [NSJSONSerialization dataWithJSONObject:uploadEvents options:0 error:&error];
-        }
-        @catch (NSException *exception) {
-            AMPLITUDE_ERROR(@"ERROR: NSJSONSerialization error: %@", exception.reason);
-            _updatingCurrently = NO;
-            return;
-        }
+        eventsDataLocal = [NSJSONSerialization dataWithJSONObject:uploadEvents options:0 error:&error];
         if (error != nil) {
             AMPLITUDE_ERROR(@"ERROR: NSJSONSerialization error: %@", error);
             _updatingCurrently = NO;
             return;
         }
-        if (eventsDataLocal) {
-            NSString *eventsString = [[NSString alloc] initWithData:eventsDataLocal encoding:NSUTF8StringEncoding];
-            [self makeEventUploadPostRequest:kAMPEventLogUrl events:eventsString maxEventId:maxEventId maxIdentifyId:maxIdentifyId];
-            SAFE_ARC_RELEASE(eventsString);
-       }
+
+        NSString *eventsString = [[NSString alloc] initWithData:eventsDataLocal encoding:NSUTF8StringEncoding];
+        if ([AMPUtils isEmptyString:eventsString]) {
+            AMPLITUDE_ERROR(@"ERROR: JSONSerialization of event upload data resulted in a NULL string");
+            _updatingCurrently = NO;
+            return;
+        }
+
+        [self makeEventUploadPostRequest:kAMPEventLogUrl events:eventsString maxEventId:maxEventId maxIdentifyId:maxIdentifyId];
+        SAFE_ARC_RELEASE(eventsString);
     }];
 }
 

--- a/AmplitudeTests/AMPDatabaseHelperTests.m
+++ b/AmplitudeTests/AMPDatabaseHelperTests.m
@@ -467,4 +467,16 @@
     XCTAssert([[self.databaseHelper getLongValue:key] isEqualToNumber:value2]);
 }
 
+- (void)testInsertNullEventString {
+    [self.databaseHelper addEvent:nil];
+    [self.databaseHelper addEvent:@"{\"event_type\":\"test1\"}"];
+    XCTAssertEqual(2, [self.databaseHelper getEventCount]);
+
+    NSArray *events = [self.databaseHelper getEvents:-1 limit:-1];  // this should not crash
+    // verify that the null event is filtered out
+    XCTAssertEqual([events count], 1);
+    XCTAssert([[[events objectAtIndex:0] objectForKey:@"event_type"] isEqualToString:@"test1"]);
+    XCTAssertEqualObjects([[events objectAtIndex:0] objectForKey:@"event_id"], [NSNumber numberWithInt:2]);
+}
+
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix crash by handling NULL events saved to and fetched from the database.
+
 ### 3.8.4 Re-release (August 19, 2016)
 
 * Added support for integration via Carthage. Thanks to @mpurland for the original PR. Thanks to @lexrus for follow up PR to fix framework naming.


### PR DESCRIPTION
Sometimes depending on the customer's instrumentation, the event serialization yields a null event. We want to detect when that happens and log an error to notify the customer.

We also need to handle null events when fetching from the database and skip over those events.