### PR TITLE
switch to unarchiving event dict with new ios 9 method

### DIFF
--- a/AmplitudeTests/Amplitude+Test.h
+++ b/AmplitudeTests/Amplitude+Test.h
@@ -27,5 +27,7 @@
 - (void)enterForeground;
 - (void)enterBackground;
 - (NSDate*)currentTime;
+- (id)unarchive:(NSString*)path;
+- (BOOL)archive:(id) obj toFile:(NSString*)path;
 
 @end

--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -748,4 +748,17 @@
     XCTAssertEqualObjects([event objectForKey:@"groups"], expectedGroups);
 }
 
+-(void)testUnarchiveEventsDict {
+    NSString *archiveName = @"test_archive";
+    NSDictionary *event = [NSDictionary dictionaryWithObject:@"test event" forKey:@"event_type"];
+    XCTAssertTrue([self.amplitude archive:event toFile:archiveName]);
+
+    NSDictionary *unarchived = [self.amplitude unarchive:archiveName];
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_4) {
+        XCTAssertEqualObjects(unarchived, event);
+    } else {
+        XCTAssertNil(unarchived);
+    }
+}
+
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Switch to unarchiving unsent events archive file with `[NSKeyedUnarchiver unarchiveObjectWithFile]` to iOS 9's `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData]`. Note: this only affects you if you are *upgrading from an SDK version older than v3.1.0 straight to v3.9.0 or newer*. Users who have not updated to iOS 9.0 or newer will lose any unsent events stored on their devices. This also removes all Objective-C Exceptions (@try/@catch) from the SDK, removing the need to toggle `Enable Objective-C Exceptions` in Xcode.
+
 ### 3.8.5 (August 29, 2016)
 
 * Fix crash by handling NULL events saved to and fetched from the database.


### PR DESCRIPTION
This removes the last objective-c try catch statement from our SDK.

We need to check the iOS version before calling the newer iOS 9 method. Checking NSFoundationVersionNumber is Apple's recommended method for checking.

The nice thing is I can run the unit test on an iOS 8 emulator as well as an iOS 9 emulator. I verified that the unarchiving works in iOS 9, and the unarchiving is skipped in iOS 8. Also if I remove the `(floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_8_4)` check and run it on iOS 8, I verify that it crashes when trying to call the new method.