### PR TITLE
Improve end session event

### DIFF
--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -388,7 +388,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
             NSString *eventString = [NSString stringWithUTF8String:rawEventString];
             NSDictionary *eventImmutable = [AMPUtils deserializeEventString:eventString];
             if (eventImmutable == nil) {
-                AMPLITUDE_LOG(@"Error JSON deserialization of event id %lld from table %@: %@", eventId, table, error);
+                AMPLITUDE_LOG(@"Failed to deserialize event from table %@", table);
                 continue;
             }
 

--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -386,11 +386,6 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
                 continue;
             }
             NSString *eventString = [NSString stringWithUTF8String:rawEventString];
-            if ([AMPUtils isEmptyString:eventString]) {
-                AMPLITUDE_LOG(@"Ignoring empty event string for event id %lld from table %@", eventId, table);
-                continue;
-            }
-
             NSDictionary *eventImmutable = [AMPUtils deserializeEventString:eventString];
             if (eventImmutable == nil) {
                 AMPLITUDE_LOG(@"Error JSON deserialization of event id %lld from table %@: %@", eventId, table, error);

--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -391,10 +391,8 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
                 continue;
             }
 
-            NSData *eventData = [eventString dataUsingEncoding:NSUTF8StringEncoding];
-            NSError *error = nil;
-            id eventImmutable = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
-            if (error != nil) {
+            NSDictionary *eventImmutable = [AMPUtils deserializeEventString:eventString];
+            if (eventImmutable == nil) {
                 AMPLITUDE_LOG(@"Error JSON deserialization of event id %lld from table %@: %@", eventId, table, error);
                 continue;
             }

--- a/Amplitude/AMPUtils.h
+++ b/Amplitude/AMPUtils.h
@@ -12,5 +12,6 @@
 + (id) makeJSONSerializable:(id) obj;
 + (BOOL) isEmptyString:(NSString*) str;
 + (NSDictionary*) validateGroups:(NSDictionary*) obj;
++ (NSDictionary*) deserializeEventString:(NSString*) eventString;
 
 @end

--- a/Amplitude/AMPUtils.m
+++ b/Amplitude/AMPUtils.m
@@ -143,6 +143,10 @@
 
 + (NSDictionary *) deserializeEventString:(NSString *)eventString
 {
+    if ([self isEmptyString:eventString]) {
+        return nil;
+    }
+
     NSData *eventData = [eventString dataUsingEncoding:NSUTF8StringEncoding];
     NSError *error = nil;
     id event = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];

--- a/Amplitude/AMPUtils.m
+++ b/Amplitude/AMPUtils.m
@@ -141,4 +141,16 @@
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
++ (NSDictionary *) deserializeEventString:(NSString *)eventString
+{
+    NSData *eventData = [eventString dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error = nil;
+    id event = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
+    if (error != nil) {
+        AMPLITUDE_LOG(@"Error JSON deserialization of event: %@", error);
+        return nil;
+    }
+    return event;
+}
+
 @end

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -1162,9 +1162,12 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             [self sendSessionEvent:kAMPSessionEndEvent timestamp:lastEventTime];
         } else {
             // sanity check the event
+            NSNumber *endSessionTimestamp = nil;
             NSDictionary *endSessionEvent = [AMPUtils deserializeEventString:endSessionEventString];
-            NSNumber *endSessionTimestamp = [endSessionEvent objectForKey:@"timestamp"];
-            if (endSessionTimestamp == nil || [endSessionTimestamp longLongValue] != [lastEventTime longLongValue]) {
+            if (endSessionEvent != nil) {
+                endSessionTimestamp = [endSessionEvent objectForKey:@"timestamp"];
+            }
+            if (endSessionEvent == nil || endSessionTimestamp == nil || [endSessionTimestamp longLongValue] != [lastEventTime longLongValue]) {
                 [self sendSessionEvent:kAMPSessionEndEvent timestamp:lastEventTime];
             }
         }

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -1151,29 +1151,22 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 - (void)startNewSession:(NSNumber*) timestamp
 {
     if (_trackingSessionEvents) {
-        [self sendSessionEvent:kAMPSessionEndEvent];
+        [self sendSessionEvent:kAMPSessionEndEvent timestamp:[self lastEventTime]];
     }
     [self setSessionId:[timestamp longLongValue]];
     [self refreshSessionTime:timestamp];
     if (_trackingSessionEvents) {
-        [self sendSessionEvent:kAMPSessionStartEvent];
+        [self sendSessionEvent:kAMPSessionStartEvent timestamp:timestamp];
     }
 }
 
-- (void)sendSessionEvent:(NSString*) sessionEvent
+- (void)sendSessionEvent:(NSString*) sessionEvent timestamp:(NSNumber *) timestamp
 {
-    if (_apiKey == nil) {
-        AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before sending session event");
+    if (_apiKey == nil || ![self inSession]) {
         return;
     }
 
-    if (![self inSession]) {
-        return;
-    }
-
-    NSMutableDictionary *apiProperties = [NSMutableDictionary dictionary];
-    [apiProperties setValue:sessionEvent forKey:@"special"];
-    NSNumber* timestamp = [self lastEventTime];
+    NSDictionary *apiProperties = [NSDictionary dictionaryWithObject:sessionEvent forKey:@"special"];
     [self logEvent:sessionEvent withEventProperties:nil withApiProperties:apiProperties withUserProperties:nil withGroups:nil withTimestamp:timestamp outOfSession:NO];
 }
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -628,6 +628,8 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         }
         if ([eventType isEqualToString:IDENTIFY_EVENT]) {
             (void) [self.dbHelper addIdentify:jsonString];
+        } else if ([eventType isEqualToString:kAMPSessionEndEvent]) {
+            (void) [self.dbHelper insertOrReplaceKeyValue:kAMPSessionEndEvent value:jsonString];
         } else {
             (void) [self.dbHelper addEvent:jsonString];
         }
@@ -1152,6 +1154,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 {
     if (_trackingSessionEvents) {
         [self sendSessionEvent:kAMPSessionEndEvent timestamp:[self lastEventTime]];
+        NSString *endSessionEventString = [self.dbHelper getValue:kAMPSessionEndEvent];
+        if (![AMPUtils isEmptyString:endSessionEventString]) {
+            [self.dbHelper addEvent:endSessionEventString];
+            [self.dbHelper insertOrReplaceKeyValue:kAMPSessionEndEvent value:nil];
+        }
     }
     [self setSessionId:[timestamp longLongValue]];
     [self refreshSessionTime:timestamp];

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -1104,6 +1104,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self runOnBackgroundQueue:^{
         _inForeground = NO;
         [self refreshSessionTime:now];
+        [self sendSessionEvent:kAMPSessionEndEvent timestamp:now];
         [self uploadEventsWithLimit:0];
     }];
 }


### PR DESCRIPTION
This addresses the issue when the end session event is logged on app open and the latest app state is logged (for example the app version name), with the old timestamp, resulting in events for certain app versions being logged before the version was actually released.

When app goes into background, we log an end session event and save it to the key value table (with session_end as the key). This end session event is timestamped at the time the app goes into the background.

When app comes into foreground and starts a new session, it checks the key value table for any saved end session events. If there isn't one, it logs one at that time (the old behavior) which will go to the key value table. It then reloads the saved end session event and just adds it to the events table. 

We sanity check the saved end session event and make sure that its timestamp is the same as the last recorded time (when app went into background).

This change should not break any existing tests since the fallback behavior is just the old behavior.