### PR TITLE
Amplitude SSL Pinning included with Amplitude's Cocoapod

### DIFF
--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Amplitude" => "dev@amplitude.com" }
   s.source       = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v3.12.1" }
   s.platform     = :ios, '5.0'
-  s.source_files = 'Amplitude/*.{h,m}'
+  s.source_files = 'Amplitude/*.{h,m}', 'Amplitude/SSLCertificatePinning/*.{h,m,pch}'
   s.requires_arc = true
   s.library 	 = 'sqlite3.0'
 end

--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Amplitude" => "dev@amplitude.com" }
   s.source       = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v3.12.1" }
   s.platform     = :ios, '5.0'
-  s.source_files = 'Amplitude/*'
+  s.source_files = 'Amplitude/*’, 'Amplitude/SSLCertificatePinning/*’
   s.requires_arc = true
   s.library 	 = 'sqlite3.0'
 end

--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Amplitude" => "dev@amplitude.com" }
   s.source       = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v3.12.1" }
   s.platform     = :ios, '5.0'
-  s.source_files = 'Amplitude/*’, 'Amplitude/SSLCertificatePinning/*’
+  s.source_files = 'Amplitude/*', 'Amplitude/SSLCertificatePinning/*'
   s.requires_arc = true
   s.library 	 = 'sqlite3.0'
 end

--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { "Amplitude" => "dev@amplitude.com" }
   s.source       = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v3.12.1" }
   s.platform     = :ios, '5.0'
-  s.source_files = 'Amplitude/*.{h,m}', 'Amplitude/SSLCertificatePinning/*.{h,m,pch}'
+  s.source_files = 'Amplitude/*'
   s.requires_arc = true
   s.library 	 = 'sqlite3.0'
 end

--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = '6.0'
   s.tvos.deployment_target = '9.0'
   s.source_files           = 'Amplitude/*', 'Amplitude/SSLCertificatePinning/*'
+  s.resources              = 'Amplitude/*.der'
   s.requires_arc           = true
   s.library 	             = 'sqlite3.0'
 end

--- a/Amplitude/SSLCertificatePinning/ISPCertificatePinning.m
+++ b/Amplitude/SSLCertificatePinning/ISPCertificatePinning.m
@@ -80,10 +80,10 @@
 
             // Compare the two certificates
             if ([pinnedCertificate isEqualToData:DERCertificate]) {
-                CFRelease(DERCertificate);
+                CFRelease((__bridge CFTypeRef)DERCertificate);
                 return YES;
             }
-            CFRelease(DERCertificate);
+            CFRelease((__bridge CFTypeRef)DERCertificate);
         }
 
         // Check the anchor/CA certificate separately


### PR DESCRIPTION
Per my correspondence with Varun, Wendy and Dan, we're hoping to enable SSL Pinning in our implementation of Amplitude. The instructions Dan gave us was to:

a. download the source from https://github.com/amplitude/Amplitude-iOS/archive/master.zip
b. install the entire 'Amplitude' subdirectory directly into our project

From my examination of your pod spec, it would appear the only reason ☝️ is necessary is because the pod spec _only_ includes .h / .m files in the top level folder. 

This PR simply modifies the pod spec to include everything in the 'Amplitude' folder, so that (hopefully) we're not forced to choose between integrating Amplitude via Cocoapods or enabling SSL Pinning.