### PR TITLE
Remove non-source files from Xcode build phase

### DIFF
--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source                 = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v3.14.0" }
   s.ios.deployment_target  = '6.0'
   s.tvos.deployment_target = '9.0'
-  s.source_files           = 'Amplitude/*', 'Amplitude/SSLCertificatePinning/*'
+  s.source_files           = 'Amplitude/*.{h,m}', 'Amplitude/SSLCertificatePinning/*.{h,m}'
   s.resources              = 'Amplitude/*.der'
   s.requires_arc           = true
   s.library 	             = 'sqlite3.0'


### PR DESCRIPTION
This fixes #132. After this change, there are no build warnings for Amplitude.