### PR TITLE
Sets APPLICATION_EXTENSION_API_ONLY = YES for Amplitude.framework target

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -721,6 +721,7 @@
 		343AB41C1CC99F4F00962943 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -749,6 +750,7 @@
 		343AB41D1CC99F4F00962943 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";


### PR DESCRIPTION
This currently causes a linker warning when using the Amplitude framework in an extension target.