### PR TITLE
Use UIApplication APIs on the main thread to avoid violations

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -475,15 +475,17 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             }
         }];
 
-        UIApplication *app = [self getSharedApplication];
-        if (app != nil) {
-            UIApplicationState state = app.applicationState;
-            if (state != UIApplicationStateBackground) {
-                // If this is called while the app is running in the background, for example
-                // via a push notification, don't call enterForeground
-                [self enterForeground];
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            UIApplication *app = [self getSharedApplication];
+            if (app != nil) {
+                UIApplicationState state = app.applicationState;
+                if (state != UIApplicationStateBackground) {
+                    // If this is called while the app is running in the background, for example
+                    // via a push notification, don't call enterForeground
+                    [self enterForeground];
+                }
             }
-        }
+        }];
         _initialized = YES;
     }
 }


### PR DESCRIPTION
Since Xcode 9 we now have a [Main Thread Checker](https://developer.apple.com/documentation/code_diagnostics/main_thread_checker) that will warn us when an API thats reserved for the main thread is used on a background thread. Where this falls apart is that if any XCTest triggers this code path the simulator hangs and as a result CI fails. There is some reading [here](http://shashikantjagtap.net/main-thread-checker-xcuitests-xcode-9/) that explores some workarounds.

<img width="1418" alt="screen shot 2017-10-11 at 4 53 55 pm" src="https://user-images.githubusercontent.com/4479146/31448492-d93d845a-aea4-11e7-8d45-2bf2368ce901.png">

In the meantime until Apple fixes this we should ensure that Amplitude uses main thread APIs on the main thread always

This closes https://github.com/amplitude/Amplitude-iOS/issues/147