### PR TITLE
Main thread violation

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -475,17 +475,21 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             }
         }];
 
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+        // Normally _inForeground is set by the enterForeground callback, but initializeWithApiKey will be called after the app's enterForeground
+        // notification is already triggered, so we need to manually check and set it now.
+        // UIApplication methods are only allowed on the main thread so need to dispatch this synchronously to the main thread.
+        void (^checkInForeground)(void) = ^{
             UIApplication *app = [self getSharedApplication];
             if (app != nil) {
                 UIApplicationState state = app.applicationState;
                 if (state != UIApplicationStateBackground) {
-                    // If this is called while the app is running in the background, for example
-                    // via a push notification, don't call enterForeground
-                    [self enterForeground];
+                    _inForeground = YES;
                 }
             }
-        }];
+        };
+        [self runSynchronouslyOnMainQueue:checkInForeground];
+        NSNumber* now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
+        [self startOrContinueSession:now];
         _initialized = YES;
     }
 }
@@ -513,10 +517,21 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         AMPLITUDE_LOG(@"Already running in the background.");
         block();
         return NO;
-    }
-    else {
+    } else {
         [_backgroundQueue addOperationWithBlock:block];
         return YES;
+    }
+}
+
+/**
+ * Run a block on the main thread. If already on the main thread, run immediately.
+ */
+- (void)runSynchronouslyOnMainQueue:(void (^)(void))block
+{
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), block);
     }
 }
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -475,15 +475,17 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             }
         }];
 
-        UIApplication *app = [self getSharedApplication];
-        if (app != nil) {
-            UIApplicationState state = app.applicationState;
-            if (state != UIApplicationStateBackground) {
-                // If this is called while the app is running in the background, for example
-                // via a push notification, don't call enterForeground
-                [self enterForeground];
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            UIApplication *app = [self getSharedApplication];
+            if (app != nil) {
+                UIApplicationState state = app.applicationState;
+                if (state != UIApplicationStateBackground) {
+                    // If this is called while the app is running in the background, for example
+                    // via a push notification, don't call enterForeground
+                    [self enterForeground];
+                }
             }
-        }
+        }];
         _initialized = YES;
     }
 }

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -48,20 +48,6 @@
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
 }
 
-//- (void)testSessionAutoStartedInactive {
-//    id mockApplication = [OCMockObject niceMockForClass:[UIApplication class]];
-//    [[[mockApplication stub] andReturn:mockApplication] sharedApplication];
-//    OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateInactive);
-//
-//    id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
-//    [[mockAmplitude expect] enterForeground];
-//    [mockAmplitude initializeApiKey:apiKey];
-//    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
-//    [mockAmplitude flushQueue];
-//    [mockAmplitude verify];
-//    XCTAssertEqual([mockAmplitude queuedEventCount], 0);
-//}
-
 - (void)testSessionHandling {
 
     // start new session on initializeApiKey

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -48,19 +48,19 @@
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
 }
 
-- (void)testSessionAutoStartedInactive {
-    id mockApplication = [OCMockObject niceMockForClass:[UIApplication class]];
-    [[[mockApplication stub] andReturn:mockApplication] sharedApplication];
-    OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateInactive);
-
-    id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
-    [[mockAmplitude expect] enterForeground];
-    [mockAmplitude initializeApiKey:apiKey];
-    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
-    [mockAmplitude flushQueue];
-    [mockAmplitude verify];
-    XCTAssertEqual([mockAmplitude queuedEventCount], 0);
-}
+//- (void)testSessionAutoStartedInactive {
+//    id mockApplication = [OCMockObject niceMockForClass:[UIApplication class]];
+//    [[[mockApplication stub] andReturn:mockApplication] sharedApplication];
+//    OCMStub([mockApplication applicationState]).andReturn(UIApplicationStateInactive);
+//
+//    id mockAmplitude = [OCMockObject partialMockForObject:self.amplitude];
+//    [[mockAmplitude expect] enterForeground];
+//    [mockAmplitude initializeApiKey:apiKey];
+//    [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
+//    [mockAmplitude flushQueue];
+//    [mockAmplitude verify];
+//    XCTAssertEqual([mockAmplitude queuedEventCount], 0);
+//}
 
 - (void)testSessionHandling {
 


### PR DESCRIPTION
`[self enterForeground]` sets the `_inForeground` flag, initializes the session information, and uploads unsent events. We manually call this method in `initializeWithApiKey` because when the SDK is initialized, the `enterForeground` notification will already have been triggered by the app.

Issue: this piece of checks application state, which is now forbidden by Apple on background threads. This causes a main queue violation warning in Xcode, and can crash unit tests.

Proposed solution: Rather than calling enterForeground, we just run the pieces of logic that are required. Similar to the Android SDK, we can always just initialize the session information in the init method on the background queue (so just call it directly). We still need to set the foreground flag, and that HAS to be done on the main queue, so we dispatch_sync an operation to just set the flag. I believe this needs to be synchronously because that flag is used in logEvent, so it has to be set before any logEvents are triggered / run on the background thread.

This is based off the PR submitted: https://github.com/amplitude/Amplitude-iOS/pull/148, which solves the violation warning but breaks all of our session tests since the tests do not wait for the main queue operation to finish running (and thus the session information is never initialized as expected). This should solve: https://github.com/segment-integrations/analytics-ios-integration-amplitude/issues/28 