### PR TITLE
add flag to disable idfa tracking

### DIFF
--- a/Amplitude/AMPDeviceInfo.h
+++ b/Amplitude/AMPDeviceInfo.h
@@ -3,7 +3,7 @@
 
 @interface AMPDeviceInfo : NSObject
 
--(id) init: (BOOL) disableIDFATracking;
+-(id) init: (BOOL) disableIdfaTracking;
 @property (readonly) NSString *appVersion;
 @property (readonly) NSString *osName;
 @property (readonly) NSString *osVersion;

--- a/Amplitude/AMPDeviceInfo.h
+++ b/Amplitude/AMPDeviceInfo.h
@@ -3,7 +3,7 @@
 
 @interface AMPDeviceInfo : NSObject
 
--(id) init;
+-(id) init: (BOOL) disableIDFATracking;
 @property (readonly) NSString *appVersion;
 @property (readonly) NSString *osName;
 @property (readonly) NSString *osVersion;

--- a/Amplitude/AMPDeviceInfo.m
+++ b/Amplitude/AMPDeviceInfo.m
@@ -16,7 +16,7 @@
 
 @implementation AMPDeviceInfo {
     NSObject* networkInfo;
-    BOOL _disableIDFATracking;
+    BOOL _disableIdfaTracking;
 }
 
 @synthesize appVersion = _appVersion;
@@ -28,9 +28,9 @@
 @synthesize advertiserID = _advertiserID;
 @synthesize vendorID = _vendorID;
 
--(id) init: (BOOL) disableIDFATracking {
+-(id) init: (BOOL) disableIdfaTracking {
     self = [super init];
-    _disableIDFATracking = disableIDFATracking;
+    _disableIdfaTracking = disableIdfaTracking;
     return self;
 }
 
@@ -118,7 +118,7 @@
 }
 
 -(NSString*) advertiserID {
-    if (!_disableIDFATracking && !_advertiserID) {
+    if (!_disableIdfaTracking && !_advertiserID) {
         if ([[[UIDevice currentDevice] systemVersion] floatValue] >= (float) 6.0) {
             NSString *advertiserId = [AMPDeviceInfo getAdvertiserID:5];
             if (advertiserId != nil &&

--- a/Amplitude/AMPDeviceInfo.m
+++ b/Amplitude/AMPDeviceInfo.m
@@ -16,6 +16,7 @@
 
 @implementation AMPDeviceInfo {
     NSObject* networkInfo;
+    BOOL _disableIDFATracking;
 }
 
 @synthesize appVersion = _appVersion;
@@ -27,11 +28,9 @@
 @synthesize advertiserID = _advertiserID;
 @synthesize vendorID = _vendorID;
 
-
-
-
--(id) init {
+-(id) init: (BOOL) disableIDFATracking {
     self = [super init];
+    _disableIDFATracking = disableIDFATracking;
     return self;
 }
 
@@ -119,7 +118,7 @@
 }
 
 -(NSString*) advertiserID {
-    if (!_advertiserID) {
+    if (!_disableIDFATracking && !_advertiserID) {
         if ([[[UIDevice currentDevice] systemVersion] floatValue] >= (float) 6.0) {
             NSString *advertiserId = [AMPDeviceInfo getAdvertiserID:5];
             if (advertiserId != nil &&

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -514,7 +514,7 @@
 
  **NOTE:** Must be called before initializeApiKey: is called to function.
  */
-- (void)disableIDFATracking;
+- (void)disableIdfaTracking;
 
 /**-----------------------------------------------------------------------------
  * @name Other Methods

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -509,6 +509,13 @@
  */
 - (void)useAdvertisingIdForDeviceId;
 
+/**
+ Disables tracking of advertisingIdentifier by the SDK
+
+ **NOTE:** Must be called before initializeApiKey: is called to function.
+ */
+- (void)disableIDFATracking;
+
 /**-----------------------------------------------------------------------------
  * @name Other Methods
  * -----------------------------------------------------------------------------

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -88,6 +88,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     AMPDeviceInfo *_deviceInfo;
     BOOL _useAdvertisingIdForDeviceId;
+    BOOL _disableIDFATracking;
 
     CLLocation *_lastKnownLocation;
     BOOL _locationListeningEnabled;
@@ -224,6 +225,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         _updateScheduled = NO;
         _updatingCurrently = NO;
         _useAdvertisingIdForDeviceId = NO;
+        _disableIDFATracking = NO;
         _backoffUpload = NO;
         _offline = NO;
         _instanceName = SAFE_ARC_RETAIN(instanceName);
@@ -247,7 +249,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         
         [_initializerQueue addOperationWithBlock:^{
             
-            _deviceInfo = [[AMPDeviceInfo alloc] init];
+            _deviceInfo = [[AMPDeviceInfo alloc] init:_disableIDFATracking];
 
             _uploadTaskID = UIBackgroundTaskInvalid;
             
@@ -1423,6 +1425,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 - (void)useAdvertisingIdForDeviceId
 {
     _useAdvertisingIdForDeviceId = YES;
+}
+
+- (void)disableIDFATracking
+{
+    _disableIDFATracking = YES;
 }
 
 #pragma mark - Getters for device data

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -88,7 +88,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     AMPDeviceInfo *_deviceInfo;
     BOOL _useAdvertisingIdForDeviceId;
-    BOOL _disableIDFATracking;
+    BOOL _disableIdfaTracking;
 
     CLLocation *_lastKnownLocation;
     BOOL _locationListeningEnabled;
@@ -225,7 +225,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         _updateScheduled = NO;
         _updatingCurrently = NO;
         _useAdvertisingIdForDeviceId = NO;
-        _disableIDFATracking = NO;
+        _disableIdfaTracking = NO;
         _backoffUpload = NO;
         _offline = NO;
         _instanceName = SAFE_ARC_RETAIN(instanceName);
@@ -249,7 +249,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         
         [_initializerQueue addOperationWithBlock:^{
             
-            _deviceInfo = [[AMPDeviceInfo alloc] init:_disableIDFATracking];
+            _deviceInfo = [[AMPDeviceInfo alloc] init:_disableIdfaTracking];
 
             _uploadTaskID = UIBackgroundTaskInvalid;
             
@@ -1427,9 +1427,9 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     _useAdvertisingIdForDeviceId = YES;
 }
 
-- (void)disableIDFATracking
+- (void)disableIdfaTracking
 {
-    _disableIDFATracking = YES;
+    _disableIdfaTracking = YES;
 }
 
 #pragma mark - Getters for device data

--- a/AmplitudeTests/DeviceInfoTests.m
+++ b/AmplitudeTests/DeviceInfoTests.m
@@ -13,6 +13,11 @@
 #import "AMPDeviceInfo.h"
 #import "AMPARCMacros.h"
 
+// expose private methods for unit testing
+@interface AMPDeviceInfo (Tests)
++(NSString*)getAdvertiserID:(int) maxAttempts;
+@end
+
 @interface DeviceInfoTests : XCTestCase
 
 @end
@@ -73,8 +78,20 @@
 }
 
 - (void) testAdvertiserID {
-    // TODO: Not sure how to test this on the simulator
-//    XCTAssertEqualObjects(nil, _deviceInfo.advertiserID);
+    id mockDeviceInfo = OCMClassMock([AMPDeviceInfo class]);
+    [[mockDeviceInfo expect] getAdvertiserID:5];
+    XCTAssertEqualObjects(nil, _deviceInfo.advertiserID);
+    [mockDeviceInfo verify];
+    [mockDeviceInfo stopMocking];
+}
+
+- (void) testDisableIDFATracking {
+    id mockDeviceInfo = OCMClassMock([AMPDeviceInfo class]);
+    [[mockDeviceInfo reject] getAdvertiserID:5];
+    AMPDeviceInfo *newDeviceInfo = [[AMPDeviceInfo alloc] init:YES];
+    XCTAssertEqualObjects(nil, newDeviceInfo.advertiserID);
+    [mockDeviceInfo verify];
+    [mockDeviceInfo stopMocking];
 }
 
 - (void) testVendorID {


### PR DESCRIPTION
Add a user-configurable flag that skips the IDFA fetching logic.
```objective-c
[[Amplitude instance] disableIdfaTracking];
[[Amplitude instance] initializeApiKey:@"my_api_key"];
```