### PR TITLE
[Debug] Fix import so it doesn't corrupt debug console

### DIFF
--- a/Amplitude/Amplitude+SSLPinning.h
+++ b/Amplitude/Amplitude+SSLPinning.h
@@ -1,4 +1,3 @@
-#ifdef AMPLITUDE_SSL_PINNING
 //
 //  Amplitude+SSLPinning
 //  Amplitude
@@ -7,11 +6,13 @@
 //  Copyright (c) 2015 Amplitude. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+#import "Amplitude.h"
 
 @interface Amplitude (SSLPinning)
 
+#ifdef AMPLITUDE_SSL_PINNING
 @property (nonatomic, assign) BOOL sslPinningEnabled;
+#endif
 
 @end
-#endif


### PR DESCRIPTION
Amplitude was corrupting our debug console because there was a missing import statement in one of the SSL extensions.

This keeps the extension but makes it a little less error prone.

<img width="1293" alt="fix amplitude" src="https://user-images.githubusercontent.com/30269720/39535314-8e1de2a6-4e01-11e8-83d8-f95c9d698e4c.png">
