### PR TITLE
Insert metadata db reset

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		60227C0C1CC5AC2F007C117B /* AMPRevenue.m in Sources */ = {isa = PBXBuildFile; fileRef = 60227C0A1CC5AB8A007C117B /* AMPRevenue.m */; };
 		60227C0E1CC5BC07007C117B /* RevenueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60227C0D1CC5BC07007C117B /* RevenueTests.m */; };
 		602A9A6B1B754E7B0067230C /* AmplitudeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 602A9A6A1B754E7B0067230C /* AmplitudeTests.m */; };
+		6041C8D021221A88003F1B38 /* DatabaseRecoveryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6041C8CF21221A88003F1B38 /* DatabaseRecoveryTests.m */; };
+		6041C8D121221A9A003F1B38 /* DatabaseRecoveryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6041C8CF21221A88003F1B38 /* DatabaseRecoveryTests.m */; };
 		60AFE7321F6B637100DF9A88 /* AMPURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AFE7311F6B636F00DF9A88 /* AMPURLSession.m */; };
 		60AFE7331F6B70EF00DF9A88 /* AMPURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 60AFE7301F6B636B00DF9A88 /* AMPURLSession.h */; };
 		60AFE7341F6B70F300DF9A88 /* AMPURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 60AFE7311F6B636F00DF9A88 /* AMPURLSession.m */; };
@@ -136,6 +138,7 @@
 		60227C0A1CC5AB8A007C117B /* AMPRevenue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPRevenue.m; sourceTree = "<group>"; };
 		60227C0D1CC5BC07007C117B /* RevenueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RevenueTests.m; sourceTree = "<group>"; };
 		602A9A6A1B754E7B0067230C /* AmplitudeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AmplitudeTests.m; sourceTree = "<group>"; };
+		6041C8CF21221A88003F1B38 /* DatabaseRecoveryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatabaseRecoveryTests.m; sourceTree = "<group>"; };
 		60AFE7301F6B636B00DF9A88 /* AMPURLSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPURLSession.h; sourceTree = "<group>"; };
 		60AFE7311F6B636F00DF9A88 /* AMPURLSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPURLSession.m; sourceTree = "<group>"; };
 		60BA92711C2376680043178E /* AMPDatabaseHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPDatabaseHelper.h; sourceTree = "<group>"; };
@@ -357,6 +360,7 @@
 				9D265EF31AB3FA2500399D93 /* SSLPinningTests.m */,
 				E98C05301A48E7FE00800C63 /* Supporting Files */,
 				60FD305F2102760500267B2A /* TrackingOptionsTest.m */,
+				6041C8CF21221A88003F1B38 /* DatabaseRecoveryTests.m */,
 			);
 			path = AmplitudeTests;
 			sourceTree = "<group>";
@@ -683,6 +687,7 @@
 				600CBC771E2EF62C001F58A9 /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				600CBC6B1E2EF609001F58A9 /* AMPConstants.m in Sources */,
 				600CBC831E2EF656001F58A9 /* SetupTests.m in Sources */,
+				6041C8D121221A9A003F1B38 /* DatabaseRecoveryTests.m in Sources */,
 				600CBC6E1E2EF611001F58A9 /* AMPIdentify.m in Sources */,
 				600CBC6C1E2EF60C001F58A9 /* AMPDatabaseHelper.m in Sources */,
 				600CBC811E2EF651001F58A9 /* RevenueTests.m in Sources */,
@@ -734,6 +739,7 @@
 				60227C0E1CC5BC07007C117B /* RevenueTests.m in Sources */,
 				60227C0C1CC5AC2F007C117B /* AMPRevenue.m in Sources */,
 				9D82D1D81AC1006600C3F321 /* SetupTests.m in Sources */,
+				6041C8D021221A88003F1B38 /* DatabaseRecoveryTests.m in Sources */,
 				60BA927A1C2376770043178E /* AMPDatabaseHelper.m in Sources */,
 				9D265EF41AB3FA2500399D93 /* SSLPinningTests.m in Sources */,
 				60FD305C210264FA00267B2A /* AMPTrackingOptions.m in Sources */,

--- a/Amplitude/AMPDatabaseHelper.h
+++ b/Amplitude/AMPDatabaseHelper.h
@@ -9,6 +9,7 @@
 @interface AMPDatabaseHelper : NSObject
 
 @property (nonatomic, strong, readonly) NSString *databasePath;
+@property (nonatomic, assign) BOOL callResetListenerOnDatabaseReset;
 
 + (AMPDatabaseHelper*)getDatabaseHelper;
 + (AMPDatabaseHelper*)getDatabaseHelper:(NSString*) instanceName;

--- a/Amplitude/AMPDatabaseHelper.h
+++ b/Amplitude/AMPDatabaseHelper.h
@@ -37,4 +37,6 @@
 - (NSString*)getValue:(NSString*) key;
 - (NSNumber*)getLongValue:(NSString*) key;
 
+- (void)setDatabaseResetListener: (void (^)(void)) listener;
+
 @end

--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -138,7 +138,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         _queue = NULL;
     }
     if (_databaseResetListener) {
-        (void) SAFE_ARC_RELEASE(_databaseResetListener);
+        SAFE_ARC_RELEASE(_databaseResetListener);
         _databaseResetListener = NULL;
     }
     SAFE_ARC_SUPER_DEALLOC();
@@ -176,11 +176,11 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 - (void)setDatabaseResetListener: (void (^)(void)) listener
 {
     if (listener == nil) {
-        (void) SAFE_ARC_RELEASE(_databaseResetListener);
+        SAFE_ARC_RELEASE(_databaseResetListener);
         return;
     }
     id copy = [listener copy];
-    (void) SAFE_ARC_RELEASE(_databaseResetListener);
+    SAFE_ARC_RELEASE(_databaseResetListener);
     _databaseResetListener = SAFE_ARC_RETAIN(copy);
 }
 

--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -34,7 +34,6 @@
     BOOL _databaseCreated;
     sqlite3 *_database;
     dispatch_queue_t _queue;
-    BOOL _callResetListenerOnDatabaseReset;
     void (^_databaseResetListener)(void);
 }
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -1171,11 +1171,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         [self uploadEventsWithLimit:0];
 
         // persist metadata back into database
-        [[self dbHelper] insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
-        [[self dbHelper] insertOrReplaceKeyValue:USER_ID value:self->_userId];
-        [[self dbHelper] insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
-        [[self dbHelper] insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
-        [[self dbHelper] insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
+        [self->_dbHelper insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
+        [self->_dbHelper insertOrReplaceKeyValue:USER_ID value:self->_userId];
+        [self->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
+        [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
+        [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
     }];
 }
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -314,6 +314,14 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             self->_lastEventTime = [self getLastEventTime];
             self->_optOut = [self loadOptOut];
 
+            [self->_dbHelper setDatabaseResetListener:^{
+                [self->_dbHelper insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
+                [self->_dbHelper insertOrReplaceKeyValue:USER_ID value:self->_userId];
+                [self->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
+                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
+                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
+            }];
+
             [self->_backgroundQueue setSuspended:NO];
         }];
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -485,12 +485,16 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
                 self->_userId = SAFE_ARC_RETAIN([self.dbHelper getValue:USER_ID]);
             }
 
+            __unsafe_unretained typeof(self) weakSelf = self;
             [self->_dbHelper setDatabaseResetListener:^{
-                [self->_dbHelper insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
-                [self->_dbHelper insertOrReplaceKeyValue:USER_ID value:self->_userId];
-                [self->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
-                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
-                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
+                __strong typeof(self) strongSelf = weakSelf;
+                if (strongSelf) {
+                    [strongSelf->_dbHelper insertOrReplaceKeyValue:DEVICE_ID value:strongSelf->_deviceId];
+                    [strongSelf->_dbHelper insertOrReplaceKeyValue:USER_ID value:strongSelf->_userId];
+                    [strongSelf->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:strongSelf->_optOut]];
+                    [strongSelf->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:strongSelf->_sessionId]];
+                    [strongSelf->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:strongSelf->_lastEventTime]];
+                }
             }];
         }];
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -314,14 +314,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             self->_lastEventTime = [self getLastEventTime];
             self->_optOut = [self loadOptOut];
 
-            [self->_dbHelper setDatabaseResetListener:^{
-                [self->_dbHelper insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
-                [self->_dbHelper insertOrReplaceKeyValue:USER_ID value:self->_userId];
-                [self->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
-                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
-                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
-            }];
-
             [self->_backgroundQueue setSuspended:NO];
         }];
 
@@ -492,6 +484,14 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             } else {
                 self->_userId = SAFE_ARC_RETAIN([self.dbHelper getValue:USER_ID]);
             }
+
+            [self->_dbHelper setDatabaseResetListener:^{
+                [self->_dbHelper insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
+                [self->_dbHelper insertOrReplaceKeyValue:USER_ID value:self->_userId];
+                [self->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
+                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
+                [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
+            }];
         }];
 
         // Normally _inForeground is set by the enterForeground callback, but initializeWithApiKey will be called after the app's enterForeground
@@ -1165,6 +1165,13 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         self->_inForeground = NO;
         [self refreshSessionTime:now];
         [self uploadEventsWithLimit:0];
+
+        // persist metadata back into database
+        [[self dbHelper] insertOrReplaceKeyValue:DEVICE_ID value:self->_deviceId];
+        [[self dbHelper] insertOrReplaceKeyValue:USER_ID value:self->_userId];
+        [[self dbHelper] insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
+        [[self dbHelper] insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
+        [[self dbHelper] insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
     }];
 }
 

--- a/AmplitudeTests/Amplitude+Test.h
+++ b/AmplitudeTests/Amplitude+Test.h
@@ -32,5 +32,6 @@
 - (NSDate*)currentTime;
 - (id)unarchive:(NSString*)path;
 - (BOOL)archive:(id) obj toFile:(NSString*)path;
+- (long long)getLastEventTime;
 
 @end

--- a/AmplitudeTests/Amplitude+Test.h
+++ b/AmplitudeTests/Amplitude+Test.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "AMPDatabaseHelper.h"
 
 @interface Amplitude (Test)
 
@@ -19,6 +20,7 @@
 @property (nonatomic, assign) BOOL backoffUpload;
 @property (nonatomic, assign) int backoffUploadBatchSize;
 @property (nonatomic, assign) BOOL sslPinningEnabled;
+@property (nonatomic, assign) AMPDatabaseHelper *dbHelper;
 
 - (void)flushQueue;
 - (void)flushQueueWithQueue:(NSOperationQueue*) queue;

--- a/AmplitudeTests/Amplitude+Test.m
+++ b/AmplitudeTests/Amplitude+Test.m
@@ -21,6 +21,7 @@
 @dynamic backoffUpload;
 @dynamic backoffUploadBatchSize;
 @dynamic sslPinningEnabled;
+@dynamic dbHelper;
 
 - (void)flushQueue {
     [self flushQueueWithQueue:[self backgroundQueue]];

--- a/AmplitudeTests/BaseTestCase.m
+++ b/AmplitudeTests/BaseTestCase.m
@@ -27,6 +27,7 @@ NSString *const userId = @"userId";
     [super setUp];
     self.amplitude = [Amplitude alloc];
     self.databaseHelper = [AMPDatabaseHelper getDatabaseHelper];
+    self.databaseHelper.callResetListenerOnDatabaseReset = NO;
     XCTAssertTrue([self.databaseHelper resetDB:NO]);
 
     [self.amplitude init];

--- a/AmplitudeTests/DatabaseRecoveryTests.m
+++ b/AmplitudeTests/DatabaseRecoveryTests.m
@@ -1,0 +1,95 @@
+//
+//  DatabaseRecoveryTest.m
+//  AmplitudeTests
+//
+//  Created by Daniel Jih on 8/13/18.
+//  Copyright © 2018 Amplitude. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <UIKit/UIKit.h>
+#import <OCMock/OCMock.h>
+#import "Amplitude.h"
+#import "AMPConstants.h"
+#import "Amplitude+Test.h"
+#import "BaseTestCase.h"
+#import "AMPDatabaseHelper.h"
+#import <sqlite3.h>
+
+
+@interface AMPDatabaseHelper (Test)
+
+- (BOOL)inDatabaseWithStatement:(NSString*) SQLString block:(void (^)(sqlite3_stmt *stmt)) block;
+
+@end
+
+
+@interface DatabaseRecoveryTests : XCTestCase
+@end
+
+@implementation DatabaseRecoveryTests {
+    NSString *instanceName;
+    Amplitude *amp;
+    AMPDatabaseHelper *dbHelper;
+}
+
+- (void)setUp {
+    [super setUp];
+    instanceName = @"recovery";
+    amp = [Amplitude instanceWithName:instanceName];
+    [amp initializeApiKey:apiKey];
+    [amp flushQueueWithQueue:amp.initializerQueue];
+    [amp flushQueueWithQueue:amp.backgroundQueue];
+    dbHelper = amp.dbHelper;
+    dbHelper.callResetListenerOnDatabaseReset = NO;
+    [dbHelper resetDB:NO];
+}
+
+- (void)tearDown {
+    [super tearDown];
+    dbHelper.callResetListenerOnDatabaseReset = NO;
+    [dbHelper resetDB:NO];
+}
+
+- (void)testDatabaseRecoverStackOverflow {
+    [amp logEvent:@"test"];
+    [amp flushQueueWithQueue:amp.backgroundQueue];
+    NSArray *events = [dbHelper getEvents:-1 limit:-1];
+    NSDictionary *event = [events lastObject];
+    XCTAssertEqualObjects([event valueForKey:@"event_type"], @"test");
+
+    NSString *deviceId = [dbHelper getValue:@"device_id"];
+    NSNumber *previousSessionId = [dbHelper getLongValue:@"previous_session_id"];
+    NSNumber *previousSessionTime = [dbHelper getLongValue:@"previous_session_time"];
+    NSNumber *sequenceNumber = [dbHelper getLongValue:@"sequence_number"];
+
+    XCTAssertNotNil(amp.deviceId);
+    XCTAssertGreaterThanOrEqual([previousSessionId intValue], 0);
+    XCTAssertGreaterThanOrEqual([previousSessionTime intValue], 0);
+    XCTAssertEqual([sequenceNumber intValue], 1);
+
+    dbHelper.callResetListenerOnDatabaseReset = YES;
+    id mockDbHelper = OCMPartialMock(dbHelper);
+    [[[mockDbHelper stub] andReturnValue:@NO] inDatabaseWithStatement:[OCMArg any] block:[OCMArg any]];
+    amp.dbHelper = mockDbHelper;
+
+    [amp logEvent:@"test"];
+    [amp flushQueueWithQueue:amp.backgroundQueue];
+
+    // verify stack overflow stopped but metadata was not re-written
+    deviceId = [dbHelper getValue:@"device_id"];
+    previousSessionId = [dbHelper getLongValue:@"previous_session_id"];
+    previousSessionTime = [dbHelper getLongValue:@"previous_session_time"];
+    sequenceNumber = [dbHelper getLongValue:@"sequence_number"];
+
+    XCTAssertNil(deviceId);
+    XCTAssertNil(previousSessionId);
+    XCTAssertNil(previousSessionTime);
+    XCTAssertNil(sequenceNumber);
+
+    [mockDbHelper stopMocking];
+    [dbHelper setDatabaseResetListener:nil];
+    amp.dbHelper = dbHelper;
+}
+
+@end

--- a/AmplitudeTests/SessionTests.m
+++ b/AmplitudeTests/SessionTests.m
@@ -97,7 +97,7 @@
     [mockAmplitude logEvent:@"continue_session"];
     [mockAmplitude flushQueue];
 
-    XCTAssertEqual([[mockAmplitude lastEventTime] longLongValue], 1001000 + self.amplitude.minTimeBetweenSessionsMillis);
+    XCTAssertEqual([mockAmplitude getLastEventTime], 1001000 + self.amplitude.minTimeBetweenSessionsMillis);
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
     XCTAssertEqual([mockAmplitude sessionId], 1000000 + self.amplitude.minTimeBetweenSessionsMillis);
 
@@ -133,7 +133,7 @@
                isEqualToNumber:[NSNumber numberWithLongLong:-1]]);
 
     // An out of session event should not continue the session
-    XCTAssertEqual([[mockAmplitude lastEventTime] longLongValue], 3000000); // event time of first no session
+    XCTAssertEqual([mockAmplitude getLastEventTime], 3000000); // event time of first no session
 }
 
 - (void)testEnterBackgroundDoesNotTrackEvent {


### PR DESCRIPTION
To make iOS SDK more resilient to SQLite exceptions, add a callback method to repersist SDK metadata (device id, user id) back into database after reset.

* Added a void block callback to AMPDatabaseHelper that can be called after resetting the database. Online sources say to hold onto a copy of the block instead of retaining the block directly.
* Next had to change how we were accessing some of the metadata, things like `optOut`, `lastEventTime` were reloaded from database every time and not kept in memory. Changed it so we only need to load them once during initialization into memory
* Once the metadata is in memory, then we can add a callback handler to re-insert them on db fail

iOS counterpart to: https://github.com/amplitude/Amplitude-Android/pull/173