### PR TITLE
Allow injection of custom Network Client

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -103,6 +103,12 @@
 		9DFBB9C71AB0D1DD0017F703 /* Amplitude+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFBB9C61AB0D1DD0017F703 /* Amplitude+Test.m */; };
 		9DFBB9CA1AB0D26E0017F703 /* BaseTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFBB9C91AB0D26E0017F703 /* BaseTestCase.m */; };
 		9DFBB9CC1AB0D47A0017F703 /* SessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DFBB9CB1AB0D47A0017F703 /* SessionTests.m */; };
+		A320B8C121801846008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
+		A320B8C221801ADD008BBC0A /* AMPNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A320B8BE218016FB008BBC0A /* AMPNetworkClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A320B8C321801AE2008BBC0A /* AMPEventUploadRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A320B8BF21801846008BBC0A /* AMPEventUploadRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A320B8C421801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
+		A320B8C521801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
+		A320B8C621801AE8008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		DA6B3BB40A3C99F08C34EDFD /* libPods-AmplitudeTVOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E203B94A494052A38E53DF /* libPods-AmplitudeTVOSTests.a */; };
 		E93C8C551A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E93C8C541A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m */; };
 		E96785EC1A48E93F00887CCD /* AMPDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E41A48E93F00887CCD /* AMPDeviceInfo.m */; };
@@ -175,6 +181,9 @@
 		9DFBB9C81AB0D26E0017F703 /* BaseTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseTestCase.h; sourceTree = "<group>"; };
 		9DFBB9C91AB0D26E0017F703 /* BaseTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BaseTestCase.m; sourceTree = "<group>"; };
 		9DFBB9CB1AB0D47A0017F703 /* SessionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionTests.m; sourceTree = "<group>"; };
+		A320B8BE218016FB008BBC0A /* AMPNetworkClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPNetworkClient.h; sourceTree = "<group>"; };
+		A320B8BF21801846008BBC0A /* AMPEventUploadRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPEventUploadRequest.h; sourceTree = "<group>"; };
+		A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMPEventUploadRequest.m; sourceTree = "<group>"; };
 		A553A7142982FCF36CA7B0D3 /* Pods-AmplitudeTVOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplitudeTVOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AmplitudeTVOSTests/Pods-AmplitudeTVOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BBEDD10CA8A6B9F1D5F260BB /* Pods-AmplitudeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplitudeTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AmplitudeTests/Pods-AmplitudeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1E203B94A494052A38E53DF /* libPods-AmplitudeTVOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AmplitudeTVOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -336,6 +345,9 @@
 				9D6E194B1ACCDE1C00352C6C /* SSLCertificatePinning */,
 				60FD3058210264C000267B2A /* AMPTrackingOptions.h */,
 				60FD305A210264FA00267B2A /* AMPTrackingOptions.m */,
+				A320B8BE218016FB008BBC0A /* AMPNetworkClient.h */,
+				A320B8BF21801846008BBC0A /* AMPEventUploadRequest.h */,
+				A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */,
 			);
 			path = Amplitude;
 			sourceTree = "<group>";
@@ -386,11 +398,13 @@
 				343AB42F1CC9A1EA00962943 /* AMPDatabaseHelper.h in Headers */,
 				343AB4331CC9A1EA00962943 /* Amplitude+SSLPinning.h in Headers */,
 				343AB4301CC9A1EA00962943 /* AMPDeviceInfo.h in Headers */,
+				A320B8C321801AE2008BBC0A /* AMPEventUploadRequest.h in Headers */,
 				343AB41A1CC99F4F00962943 /* AmplitudeFramework.h in Headers */,
 				343AB42E1CC9A1EA00962943 /* AMPConstants.h in Headers */,
 				343AB4381CC9A1EA00962943 /* ISPCertificatePinning.h in Headers */,
 				60FD3059210264C000267B2A /* AMPTrackingOptions.h in Headers */,
 				343AB42D1CC9A1EA00962943 /* AMPARCMacros.h in Headers */,
+				A320B8C221801ADD008BBC0A /* AMPNetworkClient.h in Headers */,
 				60AFE7331F6B70EF00DF9A88 /* AMPURLSession.h in Headers */,
 				343AB43A1CC9A1EA00962943 /* ISPPinnedNSURLSessionDelegate.h in Headers */,
 				343AB4311CC9A1EA00962943 /* AMPIdentify.h in Headers */,
@@ -593,6 +607,7 @@
 			files = (
 				343AB4211CC99FBA00962943 /* AMPDeviceInfo.m in Sources */,
 				343AB41F1CC99FB500962943 /* AMPConstants.m in Sources */,
+				A320B8C521801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */,
 				343AB4251CC99FC500962943 /* AMPRevenue.m in Sources */,
 				343AB42A1CC99FDA00962943 /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 				343AB4231CC99FBF00962943 /* Amplitude.m in Sources */,
@@ -629,6 +644,7 @@
 				600CBC771E2EF62C001F58A9 /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				600CBC6B1E2EF609001F58A9 /* AMPConstants.m in Sources */,
 				600CBC831E2EF656001F58A9 /* SetupTests.m in Sources */,
+				A320B8C621801AE8008BBC0A /* AMPEventUploadRequest.m in Sources */,
 				6041C8D121221A9A003F1B38 /* DatabaseRecoveryTests.m in Sources */,
 				600CBC6E1E2EF611001F58A9 /* AMPIdentify.m in Sources */,
 				600CBC6C1E2EF60C001F58A9 /* AMPDatabaseHelper.m in Sources */,
@@ -645,6 +661,7 @@
 			files = (
 				9D6E19541ACCDE1C00352C6C /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				60BA92771C2376680043178E /* AMPDatabaseHelper.m in Sources */,
+				A320B8C121801846008BBC0A /* AMPEventUploadRequest.m in Sources */,
 				60BA92781C2376680043178E /* AMPIdentify.m in Sources */,
 				60227C0B1CC5AB8A007C117B /* AMPRevenue.m in Sources */,
 				9D40E17E1AB3BF7F0095C7C6 /* AMPURLConnection.m in Sources */,
@@ -680,6 +697,7 @@
 				60BA927B1C23767B0043178E /* AMPIdentify.m in Sources */,
 				60227C0E1CC5BC07007C117B /* RevenueTests.m in Sources */,
 				60227C0C1CC5AC2F007C117B /* AMPRevenue.m in Sources */,
+				A320B8C421801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */,
 				9D82D1D81AC1006600C3F321 /* SetupTests.m in Sources */,
 				6041C8D021221A88003F1B38 /* DatabaseRecoveryTests.m in Sources */,
 				60BA927A1C2376770043178E /* AMPDatabaseHelper.m in Sources */,

--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -136,12 +136,9 @@
 		A320B8C121801846008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		A320B8C221801ADD008BBC0A /* AMPNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A320B8BE218016FB008BBC0A /* AMPNetworkClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A320B8C321801AE2008BBC0A /* AMPEventUploadRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A320B8BF21801846008BBC0A /* AMPEventUploadRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A320B8C421801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		A320B8C521801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		A320B8C621801AE8008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		A320B8C921801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A320B8C721801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h */; };
-		A320B8CA21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
-		A320B8CB21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
 		A320B8CC21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
 		A320B8CD21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
 		DA6B3BB40A3C99F08C34EDFD /* libPods-AmplitudeTVOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E203B94A494052A38E53DF /* libPods-AmplitudeTVOSTests.a */; };
@@ -152,8 +149,22 @@
 		E96786001A48FBD100887CCD /* AMPDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E41A48E93F00887CCD /* AMPDeviceInfo.m */; };
 		E96786011A48FBD100887CCD /* Amplitude.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E71A48E93F00887CCD /* Amplitude.m */; };
 		E96786021A48FBD100887CCD /* AMPLocationManagerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E91A48E93F00887CCD /* AMPLocationManagerDelegate.m */; };
-		FF1732E32260D678008C49BE /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1732DE2260D677008C49BE /* AMPNSURLSessionNetworkClient.m */; };
 		FF1732E42260D678008C49BE /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */; };
+		FF1D8B922260D79B00A0024C /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */; };
+		FF1D8B942260D80A00A0024C /* AMPEventUploadRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1732E22260D678008C49BE /* AMPEventUploadRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF1D8B952260D80A00A0024C /* AMPEventUploadRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1732E22260D678008C49BE /* AMPEventUploadRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF1D8B962260D81100A0024C /* AMPNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1732E02260D677008C49BE /* AMPNetworkClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF1D8B972260D81100A0024C /* AMPNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1732E02260D677008C49BE /* AMPNetworkClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF1D8B982260D81700A0024C /* AMPNSURLSessionNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1D8B902260D72F00A0024C /* AMPNSURLSessionNetworkClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF1D8B992260D81800A0024C /* AMPNSURLSessionNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FF1D8B902260D72F00A0024C /* AMPNSURLSessionNetworkClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FF1D8B9A2260D82100A0024C /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */; };
+		FF1D8B9B2260D82100A0024C /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */; };
+		FF1D8B9C2260D82100A0024C /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */; };
+		FF1D8B9D2260D82100A0024C /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */; };
+		FF1D8B9E2260D82200A0024C /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */; };
+		FF1D8B9F2260D82200A0024C /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */; };
+		FF1D8BA02260D82200A0024C /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */; };
+		FF1D8BA12260D82200A0024C /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -241,11 +252,11 @@
 		E98C05231A48E7FE00800C63 /* libAmplitude.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAmplitude.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E98C052E1A48E7FE00800C63 /* AmplitudeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AmplitudeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E98C05311A48E7FE00800C63 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FF1732DE2260D677008C49BE /* AMPNSURLSessionNetworkClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPNSURLSessionNetworkClient.m; sourceTree = "<group>"; };
-		FF1732DF2260D677008C49BE /* AMPNSURLSessionNetworkClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPNSURLSessionNetworkClient.h; sourceTree = "<group>"; };
 		FF1732E02260D677008C49BE /* AMPNetworkClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPNetworkClient.h; sourceTree = "<group>"; };
 		FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPEventUploadRequest.m; sourceTree = "<group>"; };
 		FF1732E22260D678008C49BE /* AMPEventUploadRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPEventUploadRequest.h; sourceTree = "<group>"; };
+		FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPNSURLSessionNetworkClient.m; sourceTree = "<group>"; };
+		FF1D8B902260D72F00A0024C /* AMPNSURLSessionNetworkClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPNSURLSessionNetworkClient.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -401,8 +412,8 @@
 				FF1732E22260D678008C49BE /* AMPEventUploadRequest.h */,
 				FF1732E12260D677008C49BE /* AMPEventUploadRequest.m */,
 				FF1732E02260D677008C49BE /* AMPNetworkClient.h */,
-				FF1732DF2260D677008C49BE /* AMPNSURLSessionNetworkClient.h */,
-				FF1732DE2260D677008C49BE /* AMPNSURLSessionNetworkClient.m */,
+				FF1D8B902260D72F00A0024C /* AMPNSURLSessionNetworkClient.h */,
+				FF1D8B8F2260D72F00A0024C /* AMPNSURLSessionNetworkClient.m */,
 				9D6E194B1ACCDE1C00352C6C /* SSLCertificatePinning */,
 			);
 			path = Amplitude;
@@ -461,7 +472,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				343AB4321CC9A1EA00962943 /* Amplitude.h in Headers */,
+				FF1D8B962260D81100A0024C /* AMPNetworkClient.h in Headers */,
 				343AB4351CC9A1EA00962943 /* AMPRevenue.h in Headers */,
+				FF1D8B942260D80A00A0024C /* AMPEventUploadRequest.h in Headers */,
+				FF1D8B982260D81700A0024C /* AMPNSURLSessionNetworkClient.h in Headers */,
 				343AB4341CC9A1EA00962943 /* AMPLocationManagerDelegate.h in Headers */,
 				343AB42F1CC9A1EA00962943 /* AMPDatabaseHelper.h in Headers */,
 				343AB4331CC9A1EA00962943 /* Amplitude+SSLPinning.h in Headers */,
@@ -494,6 +508,7 @@
 				37802BE41E86AF65003E5A8B /* Amplitude+SSLPinning.h in Headers */,
 				37802BE51E86AF65003E5A8B /* AMPDeviceInfo.h in Headers */,
 				37802BE61E86AF65003E5A8B /* AmplitudeFramework.h in Headers */,
+				FF1D8B992260D81800A0024C /* AMPNSURLSessionNetworkClient.h in Headers */,
 				6561B3D122273AD600763B04 /* AMPTrackingOptions.h in Headers */,
 				37802BE71E86AF65003E5A8B /* AMPConstants.h in Headers */,
 				37802BE81E86AF65003E5A8B /* ISPCertificatePinning.h in Headers */,
@@ -504,6 +519,8 @@
 				37802BEC1E86AF65003E5A8B /* AMPURLConnection.h in Headers */,
 				37802BED1E86AF65003E5A8B /* ISPPinnedNSURLConnectionDelegate.h in Headers */,
 				37802BEE1E86AF65003E5A8B /* AMPUtils.h in Headers */,
+				FF1D8B972260D81100A0024C /* AMPNetworkClient.h in Headers */,
+				FF1D8B952260D80A00A0024C /* AMPEventUploadRequest.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -726,9 +743,11 @@
 			files = (
 				343AB4211CC99FBA00962943 /* AMPDeviceInfo.m in Sources */,
 				343AB41F1CC99FB500962943 /* AMPConstants.m in Sources */,
+				FF1D8B9D2260D82100A0024C /* AMPNSURLSessionNetworkClient.m in Sources */,
 				A320B8C521801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */,
 				343AB4251CC99FC500962943 /* AMPRevenue.m in Sources */,
 				343AB42A1CC99FDA00962943 /* ISPPinnedNSURLSessionDelegate.m in Sources */,
+				FF1D8B9C2260D82100A0024C /* AMPEventUploadRequest.m in Sources */,
 				343AB4231CC99FBF00962943 /* Amplitude.m in Sources */,
 				343AB4281CC99FD500962943 /* ISPCertificatePinning.m in Sources */,
 				343AB4221CC99FBD00962943 /* AMPIdentify.m in Sources */,
@@ -749,10 +768,12 @@
 			files = (
 				37802BD21E86AF65003E5A8B /* AMPDeviceInfo.m in Sources */,
 				37802BD31E86AF65003E5A8B /* AMPConstants.m in Sources */,
+				FF1D8B9F2260D82200A0024C /* AMPNSURLSessionNetworkClient.m in Sources */,
 				37802BD41E86AF65003E5A8B /* AMPRevenue.m in Sources */,
 				37802BD51E86AF65003E5A8B /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 				37802BD61E86AF65003E5A8B /* Amplitude.m in Sources */,
 				6561B3D322273BEB00763B04 /* AMPTrackingOptions.m in Sources */,
+				FF1D8B9E2260D82200A0024C /* AMPEventUploadRequest.m in Sources */,
 				37802BD71E86AF65003E5A8B /* ISPCertificatePinning.m in Sources */,
 				37802BD81E86AF65003E5A8B /* AMPIdentify.m in Sources */,
 				37802BD91E86AF65003E5A8B /* AMPLocationManagerDelegate.m in Sources */,
@@ -778,10 +799,12 @@
 				600CBC7A1E2EF63A001F58A9 /* Amplitude+Test.m in Sources */,
 				600CBC781E2EF62E001F58A9 /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 				A320B8CD21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
+				FF1D8BA02260D82200A0024C /* AMPEventUploadRequest.m in Sources */,
 				600CBC6F1E2EF614001F58A9 /* Amplitude.m in Sources */,
 				600CBC701E2EF617001F58A9 /* AMPLocationManagerDelegate.m in Sources */,
 				600CBC7F1E2EF64C001F58A9 /* BaseTestCase.m in Sources */,
 				60FD305E210264FA00267B2A /* AMPTrackingOptions.m in Sources */,
+				FF1D8BA12260D82200A0024C /* AMPNSURLSessionNetworkClient.m in Sources */,
 				600CBC771E2EF62C001F58A9 /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				600CBC6B1E2EF609001F58A9 /* AMPConstants.m in Sources */,
 				600CBC831E2EF656001F58A9 /* SetupTests.m in Sources */,
@@ -806,11 +829,10 @@
 				A320B8C121801846008BBC0A /* AMPEventUploadRequest.m in Sources */,
 				60BA92781C2376680043178E /* AMPIdentify.m in Sources */,
 				60227C0B1CC5AB8A007C117B /* AMPRevenue.m in Sources */,
+				FF1D8B922260D79B00A0024C /* AMPNSURLSessionNetworkClient.m in Sources */,
 				9D40E17E1AB3BF7F0095C7C6 /* AMPURLConnection.m in Sources */,
-				FF1732E32260D678008C49BE /* AMPNSURLSessionNetworkClient.m in Sources */,
 				E96785EC1A48E93F00887CCD /* AMPDeviceInfo.m in Sources */,
 				E96785EE1A48E93F00887CCD /* AMPLocationManagerDelegate.m in Sources */,
-				A320B8CA21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
 				60BA92791C2376680043178E /* AMPUtils.m in Sources */,
 				60AFE7321F6B637100DF9A88 /* AMPURLSession.m in Sources */,
 				9DC7085A1AD4B28300949778 /* AMPConstants.m in Sources */,
@@ -827,7 +849,7 @@
 			files = (
 				9D6E19561ACCDE9000352C6C /* ISPCertificatePinning.m in Sources */,
 				60BA92801C23768E0043178E /* IdentifyTests.m in Sources */,
-				A320B8CB21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
+				FF1D8B9B2260D82100A0024C /* AMPNSURLSessionNetworkClient.m in Sources */,
 				9D6E19571ACCDE9000352C6C /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				9D6E19581ACCDE9000352C6C /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 				602A9A6B1B754E7B0067230C /* AmplitudeTests.m in Sources */,
@@ -842,7 +864,7 @@
 				60BA927B1C23767B0043178E /* AMPIdentify.m in Sources */,
 				60227C0E1CC5BC07007C117B /* RevenueTests.m in Sources */,
 				60227C0C1CC5AC2F007C117B /* AMPRevenue.m in Sources */,
-				A320B8C421801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */,
+				FF1D8B9A2260D82100A0024C /* AMPEventUploadRequest.m in Sources */,
 				9D82D1D81AC1006600C3F321 /* SetupTests.m in Sources */,
 				6041C8D021221A88003F1B38 /* DatabaseRecoveryTests.m in Sources */,
 				60BA927A1C2376770043178E /* AMPDatabaseHelper.m in Sources */,

--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -109,6 +109,11 @@
 		A320B8C421801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		A320B8C521801AE7008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
 		A320B8C621801AE8008BBC0A /* AMPEventUploadRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */; };
+		A320B8C921801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A320B8C721801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h */; };
+		A320B8CA21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
+		A320B8CB21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
+		A320B8CC21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
+		A320B8CD21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */; };
 		DA6B3BB40A3C99F08C34EDFD /* libPods-AmplitudeTVOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E203B94A494052A38E53DF /* libPods-AmplitudeTVOSTests.a */; };
 		E93C8C551A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E93C8C541A59B3B9001339A5 /* AMPLocationManagerDelegateTests.m */; };
 		E96785EC1A48E93F00887CCD /* AMPDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = E96785E41A48E93F00887CCD /* AMPDeviceInfo.m */; };
@@ -184,6 +189,8 @@
 		A320B8BE218016FB008BBC0A /* AMPNetworkClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPNetworkClient.h; sourceTree = "<group>"; };
 		A320B8BF21801846008BBC0A /* AMPEventUploadRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPEventUploadRequest.h; sourceTree = "<group>"; };
 		A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMPEventUploadRequest.m; sourceTree = "<group>"; };
+		A320B8C721801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPNSURLSessionNetworkClient.h; sourceTree = "<group>"; };
+		A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMPNSURLSessionNetworkClient.m; sourceTree = "<group>"; };
 		A553A7142982FCF36CA7B0D3 /* Pods-AmplitudeTVOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplitudeTVOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AmplitudeTVOSTests/Pods-AmplitudeTVOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BBEDD10CA8A6B9F1D5F260BB /* Pods-AmplitudeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AmplitudeTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AmplitudeTests/Pods-AmplitudeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1E203B94A494052A38E53DF /* libPods-AmplitudeTVOSTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AmplitudeTVOSTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -346,6 +353,8 @@
 				60FD3058210264C000267B2A /* AMPTrackingOptions.h */,
 				60FD305A210264FA00267B2A /* AMPTrackingOptions.m */,
 				A320B8BE218016FB008BBC0A /* AMPNetworkClient.h */,
+				A320B8C721801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h */,
+				A320B8C821801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m */,
 				A320B8BF21801846008BBC0A /* AMPEventUploadRequest.h */,
 				A320B8C021801846008BBC0A /* AMPEventUploadRequest.m */,
 			);
@@ -399,6 +408,7 @@
 				343AB4331CC9A1EA00962943 /* Amplitude+SSLPinning.h in Headers */,
 				343AB4301CC9A1EA00962943 /* AMPDeviceInfo.h in Headers */,
 				A320B8C321801AE2008BBC0A /* AMPEventUploadRequest.h in Headers */,
+				A320B8C921801B4A008BBC0A /* AMPNSURLSessionNetworkClient.h in Headers */,
 				343AB41A1CC99F4F00962943 /* AmplitudeFramework.h in Headers */,
 				343AB42E1CC9A1EA00962943 /* AMPConstants.h in Headers */,
 				343AB4381CC9A1EA00962943 /* ISPCertificatePinning.h in Headers */,
@@ -613,6 +623,7 @@
 				343AB4231CC99FBF00962943 /* Amplitude.m in Sources */,
 				343AB4281CC99FD500962943 /* ISPCertificatePinning.m in Sources */,
 				343AB4221CC99FBD00962943 /* AMPIdentify.m in Sources */,
+				A320B8CC21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
 				343AB4241CC99FC200962943 /* AMPLocationManagerDelegate.m in Sources */,
 				60AFE7351F6B70F300DF9A88 /* AMPURLSession.m in Sources */,
 				343AB4271CC99FC900962943 /* AMPUtils.m in Sources */,
@@ -637,6 +648,7 @@
 				600CBC761E2EF629001F58A9 /* ISPCertificatePinning.m in Sources */,
 				600CBC7A1E2EF63A001F58A9 /* Amplitude+Test.m in Sources */,
 				600CBC781E2EF62E001F58A9 /* ISPPinnedNSURLSessionDelegate.m in Sources */,
+				A320B8CD21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
 				600CBC6F1E2EF614001F58A9 /* Amplitude.m in Sources */,
 				600CBC701E2EF617001F58A9 /* AMPLocationManagerDelegate.m in Sources */,
 				600CBC7F1E2EF64C001F58A9 /* BaseTestCase.m in Sources */,
@@ -667,6 +679,7 @@
 				9D40E17E1AB3BF7F0095C7C6 /* AMPURLConnection.m in Sources */,
 				E96785EC1A48E93F00887CCD /* AMPDeviceInfo.m in Sources */,
 				E96785EE1A48E93F00887CCD /* AMPLocationManagerDelegate.m in Sources */,
+				A320B8CA21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
 				60BA92791C2376680043178E /* AMPUtils.m in Sources */,
 				60AFE7321F6B637100DF9A88 /* AMPURLSession.m in Sources */,
 				9DC7085A1AD4B28300949778 /* AMPConstants.m in Sources */,
@@ -683,6 +696,7 @@
 			files = (
 				9D6E19561ACCDE9000352C6C /* ISPCertificatePinning.m in Sources */,
 				60BA92801C23768E0043178E /* IdentifyTests.m in Sources */,
+				A320B8CB21801B4A008BBC0A /* AMPNSURLSessionNetworkClient.m in Sources */,
 				9D6E19571ACCDE9000352C6C /* ISPPinnedNSURLConnectionDelegate.m in Sources */,
 				9D6E19581ACCDE9000352C6C /* ISPPinnedNSURLSessionDelegate.m in Sources */,
 				602A9A6B1B754E7B0067230C /* AmplitudeTests.m in Sources */,

--- a/Amplitude/AMPEventUploadRequest.h
+++ b/Amplitude/AMPEventUploadRequest.h
@@ -8,8 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 NS_SWIFT_NAME(EventUploadRequest)
 @interface AMPEventUploadRequest : NSObject
 
@@ -18,7 +16,12 @@ NS_SWIFT_NAME(EventUploadRequest)
 @property (nonatomic, strong, nonnull) NSString *events;
 @property (nonatomic, assign) long long uploadTime;
 @property (nonatomic, strong, nonnull) NSString *checksum;
+@property (nonatomic, strong, nonnull) NSURL *url;
 
+- (nonnull instancetype)initWithApiVersion: (int) apiVersion
+                            apiKey: (nonnull NSString *) apiKey
+                            events: (nonnull NSString *) events
+                        uploadTime: (long long) uploadTime
+                          checksum: (nonnull NSString *)checksum
+                               url: (nonnull NSURL *)url;
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Amplitude/AMPEventUploadRequest.h
+++ b/Amplitude/AMPEventUploadRequest.h
@@ -12,16 +12,16 @@ NS_SWIFT_NAME(EventUploadRequest)
 @interface AMPEventUploadRequest : NSObject
 
 @property (nonatomic, assign) int apiVersion;
-@property (nonatomic, strong, nonnull) NSString *apiKey;
-@property (nonatomic, strong, nonnull) NSString *events;
+@property (nonatomic, strong) NSString *apiKey;
+@property (nonatomic, strong) NSString *events;
 @property (nonatomic, assign) long long uploadTime;
-@property (nonatomic, strong, nonnull) NSString *checksum;
-@property (nonatomic, strong, nonnull) NSURL *url;
+@property (nonatomic, strong) NSString *checksum;
+@property (nonatomic, strong) NSURL *url;
 
-- (nonnull instancetype)initWithApiVersion: (int) apiVersion
-                            apiKey: (nonnull NSString *) apiKey
-                            events: (nonnull NSString *) events
+- (instancetype)initWithApiVersion: (int) apiVersion
+                            apiKey: (NSString *) apiKey
+                            events: (NSString *) events
                         uploadTime: (long long) uploadTime
-                          checksum: (nonnull NSString *)checksum
-                               url: (nonnull NSURL *)url;
+                          checksum: (NSString *)checksum
+                               url: (NSURL *)url;
 @end

--- a/Amplitude/AMPEventUploadRequest.h
+++ b/Amplitude/AMPEventUploadRequest.h
@@ -11,17 +11,15 @@
 NS_SWIFT_NAME(EventUploadRequest)
 @interface AMPEventUploadRequest : NSObject
 
-@property (nonatomic, assign) int apiVersion;
-@property (nonatomic, strong) NSString *apiKey;
-@property (nonatomic, strong) NSString *events;
-@property (nonatomic, assign) long long uploadTime;
-@property (nonatomic, strong) NSString *checksum;
+@property (nonatomic, strong) NSString *httpMethod;
+@property (nonatomic, strong) NSMutableData *httpBody;
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *> *httpHeaders;
 @property (nonatomic, strong) NSURL *url;
 
-- (instancetype)initWithApiVersion: (int) apiVersion
-                            apiKey: (NSString *) apiKey
-                            events: (NSString *) events
-                        uploadTime: (long long) uploadTime
-                          checksum: (NSString *)checksum
-                               url: (NSURL *)url;
+
+- (instancetype)initWithMethod: (NSString *) httpMethod
+                          body: (NSMutableData *) httpBody
+                       headers: (NSDictionary<NSString *, NSString *> *) httpHeaders
+                           url: (NSURL *)url;
+
 @end

--- a/Amplitude/AMPEventUploadRequest.h
+++ b/Amplitude/AMPEventUploadRequest.h
@@ -1,0 +1,24 @@
+//
+//  AMPEventUploadRequest.h
+//  Amplitude
+//
+//  Created by Francesco Perrotti Garcia on 10/24/18.
+//  Copyright © 2018 Amplitude. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(EventUploadRequest)
+@interface AMPEventUploadRequest : NSObject
+
+@property (nonatomic, assign) int apiVersion;
+@property (nonatomic, strong, nonnull) NSString *apiKey;
+@property (nonatomic, strong, nonnull) NSString *events;
+@property (nonatomic, assign) long long uploadTime;
+@property (nonatomic, strong, nonnull) NSString *checksum;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Amplitude/AMPEventUploadRequest.m
+++ b/Amplitude/AMPEventUploadRequest.m
@@ -17,11 +17,11 @@
 @synthesize url = _url;
 
 - (instancetype)initWithApiVersion: (int) apiVersion
-                            apiKey: (nonnull NSString *) apiKey
-                            events: (nonnull NSString *) events
+                            apiKey: (NSString *) apiKey
+                            events: (NSString *) events
                         uploadTime: (long long) uploadTime
-                          checksum: (nonnull NSString *)checksum
-                               url: (nonnull NSURL *)url {
+                          checksum: (NSString *)checksum
+                               url: (NSURL *)url {
     self = [super init];
     _apiVersion = apiVersion;
     _apiKey = apiKey;

--- a/Amplitude/AMPEventUploadRequest.m
+++ b/Amplitude/AMPEventUploadRequest.m
@@ -1,0 +1,39 @@
+//
+//  AMPEventUploadRequest.m
+//  Amplitude
+//
+//  Created by Francesco Perrotti Garcia on 10/24/18.
+//  Copyright © 2018 Amplitude. All rights reserved.
+//
+
+#import "AMPEventUploadRequest.h"
+#import "AMPARCMacros.h"
+
+@implementation AMPEventUploadRequest
+
+@synthesize apiKey = _apiKey;
+@synthesize events = _events;
+@synthesize checksum = _checksum;
+
+- (instancetype)initWithApiVersion: (int) apiVersion
+                            apiKey: (nonnull NSString *) apiKey
+                            events: (nonnull NSString *) events
+                        uploadTime: (long long) uploadTime
+                          checksum: (nonnull NSString *)checksum {
+    self = [super init];
+    _apiVersion = apiVersion;
+    _apiKey = apiKey;
+    _events = events;
+    _uploadTime = uploadTime;
+    _checksum = checksum;
+    return self;
+}
+
+- (void) dealloc {
+    SAFE_ARC_RELEASE(_apiKey);
+    SAFE_ARC_RELEASE(_events);
+    SAFE_ARC_RELEASE(_checksum);
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+@end

--- a/Amplitude/AMPEventUploadRequest.m
+++ b/Amplitude/AMPEventUploadRequest.m
@@ -14,18 +14,21 @@
 @synthesize apiKey = _apiKey;
 @synthesize events = _events;
 @synthesize checksum = _checksum;
+@synthesize url = _url;
 
 - (instancetype)initWithApiVersion: (int) apiVersion
                             apiKey: (nonnull NSString *) apiKey
                             events: (nonnull NSString *) events
                         uploadTime: (long long) uploadTime
-                          checksum: (nonnull NSString *)checksum {
+                          checksum: (nonnull NSString *)checksum
+                               url: (nonnull NSURL *)url {
     self = [super init];
     _apiVersion = apiVersion;
     _apiKey = apiKey;
     _events = events;
     _uploadTime = uploadTime;
     _checksum = checksum;
+    _url = url;
     return self;
 }
 
@@ -33,6 +36,7 @@
     SAFE_ARC_RELEASE(_apiKey);
     SAFE_ARC_RELEASE(_events);
     SAFE_ARC_RELEASE(_checksum);
+    SAFE_ARC_RELEASE(_url);
     SAFE_ARC_SUPER_DEALLOC();
 }
 

--- a/Amplitude/AMPEventUploadRequest.m
+++ b/Amplitude/AMPEventUploadRequest.m
@@ -11,31 +11,27 @@
 
 @implementation AMPEventUploadRequest
 
-@synthesize apiKey = _apiKey;
-@synthesize events = _events;
-@synthesize checksum = _checksum;
+@synthesize httpMethod = _httpMethod;
+@synthesize httpBody = _httpBody;
+@synthesize httpHeaders = _httpHeaders;
 @synthesize url = _url;
 
-- (instancetype)initWithApiVersion: (int) apiVersion
-                            apiKey: (NSString *) apiKey
-                            events: (NSString *) events
-                        uploadTime: (long long) uploadTime
-                          checksum: (NSString *)checksum
-                               url: (NSURL *)url {
+- (instancetype)initWithMethod: (NSString *) httpMethod
+                          body: (NSMutableData *) httpBody
+                       headers: (NSDictionary<NSString *, NSString *> *) httpHeaders
+                           url: (NSURL *)url {
     self = [super init];
-    _apiVersion = apiVersion;
-    _apiKey = apiKey;
-    _events = events;
-    _uploadTime = uploadTime;
-    _checksum = checksum;
+    _httpMethod = httpMethod;
+    _httpBody = httpBody;
+    _httpHeaders = httpHeaders;
     _url = url;
     return self;
 }
 
 - (void) dealloc {
-    SAFE_ARC_RELEASE(_apiKey);
-    SAFE_ARC_RELEASE(_events);
-    SAFE_ARC_RELEASE(_checksum);
+    SAFE_ARC_RELEASE(_httpMethod);
+    SAFE_ARC_RELEASE(_httpBody);
+    SAFE_ARC_RELEASE(_httpHeaders);
     SAFE_ARC_RELEASE(_url);
     SAFE_ARC_SUPER_DEALLOC();
 }

--- a/Amplitude/AMPNSURLSessionNetworkClient.h
+++ b/Amplitude/AMPNSURLSessionNetworkClient.h
@@ -1,0 +1,16 @@
+//
+//  AMPNSURLSessionNetworkClient.h
+//  Amplitude
+//
+//  Created by Francesco Perrotti Garcia on 10/24/18.
+//  Copyright © 2018 Amplitude. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "AMPNetworkClient.h"
+
+@interface AMPNSURLSessionNetworkClient : NSObject <AMPNetworkClient>
+
+- (nonnull instancetype) initWithNSURLSession: (nonnull NSURLSession *) session;
+
+@end

--- a/Amplitude/AMPNSURLSessionNetworkClient.h
+++ b/Amplitude/AMPNSURLSessionNetworkClient.h
@@ -11,6 +11,6 @@
 
 @interface AMPNSURLSessionNetworkClient : NSObject <AMPNetworkClient>
 
-- (nonnull instancetype) initWithNSURLSession: (nonnull NSURLSession *) session;
+- (nonnull instancetype) init;
 
 @end

--- a/Amplitude/AMPNSURLSessionNetworkClient.h
+++ b/Amplitude/AMPNSURLSessionNetworkClient.h
@@ -11,6 +11,6 @@
 
 @interface AMPNSURLSessionNetworkClient : NSObject <AMPNetworkClient>
 
-- (nonnull instancetype) init;
+- (instancetype) init;
 
 @end

--- a/Amplitude/AMPNSURLSessionNetworkClient.m
+++ b/Amplitude/AMPNSURLSessionNetworkClient.m
@@ -11,7 +11,7 @@
 #import "AMPEventUploadRequest.h"
 
 @interface AMPNSURLSessionNetworkClient()
-@property (nonatomic, strong, nonnull) NSURLSession *session;
+@property (nonatomic, strong) NSURLSession *session;
 @end
 
 @implementation AMPNSURLSessionNetworkClient
@@ -19,7 +19,7 @@
     return [super init];
 }
 
-- (void) uploadEvents: (nonnull AMPEventUploadRequest *) uploadRequest using: (nonnull NSURLSession *) session completionHandler: (void (^ _Nonnull )(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler {
+- (void) uploadEvents: (AMPEventUploadRequest *) uploadRequest using: (NSURLSession *) session completionHandler: (void (^)(NSData *  data, NSURLResponse *response, NSError *error)) completionHandler {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uploadRequest.url];
     [request setTimeoutInterval:60.0];
 

--- a/Amplitude/AMPNSURLSessionNetworkClient.m
+++ b/Amplitude/AMPNSURLSessionNetworkClient.m
@@ -23,38 +23,12 @@
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uploadRequest.url];
     [request setTimeoutInterval:60.0];
 
-    NSString *apiVersionString = [[NSNumber numberWithInt:uploadRequest.apiVersion] stringValue];
-
-    NSMutableData *postData = [[NSMutableData alloc] init];
-    [postData appendData:[@"v=" dataUsingEncoding:NSUTF8StringEncoding]];
-    [postData appendData:[apiVersionString dataUsingEncoding:NSUTF8StringEncoding]];
-    [postData appendData:[@"&client=" dataUsingEncoding:NSUTF8StringEncoding]];
-    [postData appendData:[uploadRequest.apiKey dataUsingEncoding:NSUTF8StringEncoding]];
-    [postData appendData:[@"&e=" dataUsingEncoding:NSUTF8StringEncoding]];
-    [postData appendData:[[self urlEncodeString:uploadRequest.events] dataUsingEncoding:NSUTF8StringEncoding]];
-
-    // Add timestamp of upload
-    [postData appendData:[@"&upload_time=" dataUsingEncoding:NSUTF8StringEncoding]];
-    NSString *timestampString = [[NSNumber numberWithLongLong: uploadRequest.uploadTime] stringValue];
-    [postData appendData:[timestampString dataUsingEncoding:NSUTF8StringEncoding]];
-
-    [postData appendData:[@"&checksum=" dataUsingEncoding:NSUTF8StringEncoding]];
-    [postData appendData:[uploadRequest.checksum dataUsingEncoding:NSUTF8StringEncoding]];
-
-    [request setHTTPMethod:@"POST"];
-    [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[postData length]] forHTTPHeaderField:@"Content-Length"];
-
-    [request setHTTPBody:postData];
-
-    SAFE_ARC_RELEASE(postData);
+    request.HTTPMethod = uploadRequest.httpMethod;
+    request.HTTPBody = uploadRequest.httpBody;
+    request.allHTTPHeaderFields = uploadRequest.httpHeaders;
 
     [[session dataTaskWithRequest:request completionHandler:completionHandler] resume];
 }
 
-- (NSString*)urlEncodeString:(NSString*) string {
-    NSCharacterSet * allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@":/?#[]@!$ &'()*+,;=\"<>%{}|\\^~`"] invertedSet];
-    return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
-}
 
 @end

--- a/Amplitude/AMPNSURLSessionNetworkClient.m
+++ b/Amplitude/AMPNSURLSessionNetworkClient.m
@@ -1,0 +1,67 @@
+//
+//  AMPNSURLSessionNetworkClient.m
+//  Amplitude
+//
+//  Created by Francesco Perrotti Garcia on 10/24/18.
+//  Copyright © 2018 Amplitude. All rights reserved.
+//
+
+#import "AMPNSURLSessionNetworkClient.h"
+#import "AMPARCMacros.h"
+#import "AMPEventUploadRequest.h"
+
+@interface AMPNSURLSessionNetworkClient()
+@property (nonatomic, strong, nonnull) NSURLSession *session;
+@end
+
+@implementation AMPNSURLSessionNetworkClient
+- (instancetype) initWithNSURLSession: (NSURLSession *) session {
+    self = [super init];
+    _session = session;
+    return self;
+}
+
+- (void)uploadEvents:(nonnull AMPEventUploadRequest *)uploadRequest completionHandler:(void (^)(NSData * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable))completionHandler {
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uploadRequest.url];
+    [request setTimeoutInterval:60.0];
+
+    NSString *apiVersionString = [[NSNumber numberWithInt:uploadRequest.apiVersion] stringValue];
+
+    NSMutableData *postData = [[NSMutableData alloc] init];
+    [postData appendData:[@"v=" dataUsingEncoding:NSUTF8StringEncoding]];
+    [postData appendData:[apiVersionString dataUsingEncoding:NSUTF8StringEncoding]];
+    [postData appendData:[@"&client=" dataUsingEncoding:NSUTF8StringEncoding]];
+    [postData appendData:[uploadRequest.apiKey dataUsingEncoding:NSUTF8StringEncoding]];
+    [postData appendData:[@"&e=" dataUsingEncoding:NSUTF8StringEncoding]];
+    [postData appendData:[[self urlEncodeString:uploadRequest.events] dataUsingEncoding:NSUTF8StringEncoding]];
+
+    // Add timestamp of upload
+    [postData appendData:[@"&upload_time=" dataUsingEncoding:NSUTF8StringEncoding]];
+    NSString *timestampString = [[NSNumber numberWithLongLong: uploadRequest.uploadTime] stringValue];
+    [postData appendData:[timestampString dataUsingEncoding:NSUTF8StringEncoding]];
+
+    [postData appendData:[@"&checksum=" dataUsingEncoding:NSUTF8StringEncoding]];
+    [postData appendData:[uploadRequest.checksum dataUsingEncoding:NSUTF8StringEncoding]];
+
+    [request setHTTPMethod:@"POST"];
+    [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[postData length]] forHTTPHeaderField:@"Content-Length"];
+
+    [request setHTTPBody:postData];
+
+    SAFE_ARC_RELEASE(postData);
+
+    [[self.session dataTaskWithRequest:request completionHandler:completionHandler] resume];
+}
+
+- (NSString*)urlEncodeString:(NSString*) string {
+    NSCharacterSet * allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@":/?#[]@!$ &'()*+,;=\"<>%{}|\\^~`"] invertedSet];
+    return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
+}
+
+- (void) dealloc {
+    SAFE_ARC_RELEASE(_session);
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+@end

--- a/Amplitude/AMPNSURLSessionNetworkClient.m
+++ b/Amplitude/AMPNSURLSessionNetworkClient.m
@@ -15,13 +15,11 @@
 @end
 
 @implementation AMPNSURLSessionNetworkClient
-- (instancetype) initWithNSURLSession: (NSURLSession *) session {
-    self = [super init];
-    _session = session;
-    return self;
+- (instancetype) init {
+    return [super init];
 }
 
-- (void)uploadEvents:(nonnull AMPEventUploadRequest *)uploadRequest completionHandler:(void (^)(NSData * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable))completionHandler {
+- (void) uploadEvents: (nonnull AMPEventUploadRequest *) uploadRequest using: (nonnull NSURLSession *) session completionHandler: (void (^ _Nonnull )(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uploadRequest.url];
     [request setTimeoutInterval:60.0];
 
@@ -51,17 +49,12 @@
 
     SAFE_ARC_RELEASE(postData);
 
-    [[self.session dataTaskWithRequest:request completionHandler:completionHandler] resume];
+    [[session dataTaskWithRequest:request completionHandler:completionHandler] resume];
 }
 
 - (NSString*)urlEncodeString:(NSString*) string {
     NSCharacterSet * allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@":/?#[]@!$ &'()*+,;=\"<>%{}|\\^~`"] invertedSet];
     return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
-}
-
-- (void) dealloc {
-    SAFE_ARC_RELEASE(_session);
-    SAFE_ARC_SUPER_DEALLOC();
 }
 
 @end

--- a/Amplitude/AMPNetworkClient.h
+++ b/Amplitude/AMPNetworkClient.h
@@ -11,6 +11,6 @@
 NS_SWIFT_NAME(NetworkClient)
 @protocol AMPNetworkClient <NSObject>
 
-- (void) uploadEvents: (nonnull AMPEventUploadRequest *) request completionHandler: (void (^ _Nonnull )(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler;
+- (void) uploadEvents: (nonnull AMPEventUploadRequest *) uploadRequest using: (nonnull NSURLSession *) session completionHandler: (void (^ _Nonnull )(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler;
 
 @end

--- a/Amplitude/AMPNetworkClient.h
+++ b/Amplitude/AMPNetworkClient.h
@@ -1,0 +1,14 @@
+//
+//  NetworkClient.h
+//  Amplitude
+//
+//  Created by Francesco Perrotti Garcia on 10/23/18.
+//  Copyright © 2018 Amplitude. All rights reserved.
+//
+
+NS_SWIFT_NAME(NetworkClient)
+@protocol AMPNetworkClient <NSObject>
+
+- (void) uploadEvents: (nonnull AMPEventUploadRequest *) request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
+
+@end

--- a/Amplitude/AMPNetworkClient.h
+++ b/Amplitude/AMPNetworkClient.h
@@ -11,6 +11,6 @@
 NS_SWIFT_NAME(NetworkClient)
 @protocol AMPNetworkClient <NSObject>
 
-- (void) uploadEvents: (nonnull AMPEventUploadRequest *) uploadRequest using: (nonnull NSURLSession *) session completionHandler: (void (^ _Nonnull )(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler;
+- (void) uploadEvents: (AMPEventUploadRequest *) uploadRequest using: (NSURLSession *) session completionHandler: (void (^)(NSData *data, NSURLResponse *response, NSError *error)) completionHandler;
 
 @end

--- a/Amplitude/AMPNetworkClient.h
+++ b/Amplitude/AMPNetworkClient.h
@@ -11,6 +11,6 @@
 NS_SWIFT_NAME(NetworkClient)
 @protocol AMPNetworkClient <NSObject>
 
-- (void) uploadEvents: (nonnull AMPEventUploadRequest *) request completionHandler: (void (^)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler;
+- (void) uploadEvents: (nonnull AMPEventUploadRequest *) request completionHandler: (void (^ _Nonnull )(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler;
 
 @end

--- a/Amplitude/AMPNetworkClient.h
+++ b/Amplitude/AMPNetworkClient.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Amplitude. All rights reserved.
 //
 
-@class AMPEventUploadRequest;
+#import "AMPEventUploadRequest.h"
 
 NS_SWIFT_NAME(NetworkClient)
 @protocol AMPNetworkClient <NSObject>

--- a/Amplitude/AMPNetworkClient.h
+++ b/Amplitude/AMPNetworkClient.h
@@ -6,9 +6,11 @@
 //  Copyright © 2018 Amplitude. All rights reserved.
 //
 
+@class AMPEventUploadRequest;
+
 NS_SWIFT_NAME(NetworkClient)
 @protocol AMPNetworkClient <NSObject>
 
-- (void) uploadEvents: (nonnull AMPEventUploadRequest *) request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
+- (void) uploadEvents: (nonnull AMPEventUploadRequest *) request completionHandler: (void (^)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error)) completionHandler;
 
 @end

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -141,7 +141,7 @@ Network client to be used for event upload requests.
 
  @see [Tracking Events to Multiple Amplitude Apps](https://github.com/amplitude/amplitude-ios#tracking-events-to-multiple-amplitude-apps)
  */
-+ (Amplitude *)instanceWithName:(NSString*) instanceName networkClient:(id <AMPNetworkClient>) client;
++ (Amplitude *)instanceWithName:(NSString*) instanceName networkClient:(id <AMPNetworkClient>) networkClient;
 
 /**-----------------------------------------------------------------------------
  * @name Initialize the Amplitude SDK with your Amplitude API Key

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -5,7 +5,7 @@
 #import "AMPIdentify.h"
 #import "AMPRevenue.h"
 #import "AMPTrackingOptions.h"
-
+#import "AMPNetworkClient.h"
 
 /**
  Amplitude iOS SDK.

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -100,6 +100,10 @@
  */
 @property (nonatomic, assign) BOOL trackingSessionEvents;
 
+/**
+Network client to be used for event upload requests.
+ */
+@property (nonatomic, strong, nonnull) id<AMPNetworkClient> networkClient;
 
 #pragma mark - Methods
 
@@ -125,6 +129,19 @@
  @see [Tracking Events to Multiple Amplitude Apps](https://github.com/amplitude/amplitude-ios#tracking-events-to-multiple-amplitude-apps)
  */
 + (Amplitude *)instanceWithName:(NSString*) instanceName;
+
+/**
+ This fetches a named SDK instance. Use this if logging events to multiple Amplitude apps.
+
+ @param instanceName the name of the SDK instance to fetch.
+
+ @param networkClient the network client to be used for the upload requests.
+
+ @returns the Amplitude SDK instance corresponding to `instanceName`
+
+ @see [Tracking Events to Multiple Amplitude Apps](https://github.com/amplitude/amplitude-ios#tracking-events-to-multiple-amplitude-apps)
+ */
++ (Amplitude *)instanceWithName:(NSString*) instanceName networkClient:(id <AMPNetworkClient>) client;
 
 /**-----------------------------------------------------------------------------
  * @name Initialize the Amplitude SDK with your Amplitude API Key

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -103,7 +103,7 @@
 /**
 Network client to be used for event upload requests.
  */
-@property (nonatomic, strong, nonnull) id<AMPNetworkClient> networkClient;
+@property (nonatomic, strong) id<AMPNetworkClient> networkClient;
 
 #pragma mark - Methods
 
@@ -135,7 +135,7 @@ Network client to be used for event upload requests.
 
  @param instanceName the name of the SDK instance to fetch.
 
- @param networkClient the network client to be used for the upload requests.
+ @param client the network client to be used for the upload requests.
 
  @returns the Amplitude SDK instance corresponding to `instanceName`
 

--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -130,18 +130,6 @@ Network client to be used for event upload requests.
  */
 + (Amplitude *)instanceWithName:(NSString*) instanceName;
 
-/**
- This fetches a named SDK instance. Use this if logging events to multiple Amplitude apps.
-
- @param instanceName the name of the SDK instance to fetch.
-
- @param client the network client to be used for the upload requests.
-
- @returns the Amplitude SDK instance corresponding to `instanceName`
-
- @see [Tracking Events to Multiple Amplitude Apps](https://github.com/amplitude/amplitude-ios#tracking-events-to-multiple-amplitude-apps)
- */
-+ (Amplitude *)instanceWithName:(NSString*) instanceName networkClient:(id <AMPNetworkClient>) networkClient;
 
 /**-----------------------------------------------------------------------------
  * @name Initialize the Amplitude SDK with your Amplitude API Key

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -115,6 +115,10 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 + (Amplitude *)instanceWithName:(NSString*)instanceName {
+    return [Amplitude instanceWithName:nil networkClient:nil];
+}
+
++ (Amplitude *)instanceWithName:(NSString*) instanceName networkClient:(id <AMPNetworkClient>) networkClient {
     static NSMutableDictionary *_instances = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -131,7 +135,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     @synchronized(_instances) {
         client = [_instances objectForKey:instanceName];
         if (client == nil) {
-            client = [[self alloc] initWithInstanceName:instanceName];
+            client = [[self alloc] initWithInstanceName:instanceName networkClient:networkClient];
             [_instances setObject:client forKey:instanceName];
             SAFE_ARC_RELEASE(client);
         }
@@ -139,6 +143,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     return client;
 }
+
 
 + (void)initializeApiKey:(NSString*) apiKey {
     [[Amplitude instance] initializeApiKey:apiKey];
@@ -213,8 +218,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (id)initWithInstanceName:(NSString*) instanceName
 {
-    id<AMPNetworkClient> client = [[AMPNSURLSessionNetworkClient alloc] init];
-
     return [self initWithInstanceName:instanceName networkClient:nil];
 }
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -115,10 +115,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 + (Amplitude *)instanceWithName:(NSString*)instanceName {
-    return [Amplitude instanceWithName:nil networkClient:nil];
-}
-
-+ (Amplitude *)instanceWithName:(NSString*) instanceName networkClient:(id <AMPNetworkClient>) networkClient {
     static NSMutableDictionary *_instances = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -135,7 +131,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     @synchronized(_instances) {
         client = [_instances objectForKey:instanceName];
         if (client == nil) {
-            client = [[self alloc] initWithInstanceName:instanceName networkClient:networkClient];
+            client = [[self alloc] initWithInstanceName:instanceName];
             [_instances setObject:client forKey:instanceName];
             SAFE_ARC_RELEASE(client);
         }
@@ -143,7 +139,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     return client;
 }
-
 
 + (void)initializeApiKey:(NSString*) apiKey {
     [[Amplitude instance] initializeApiKey:apiKey];
@@ -218,11 +213,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (id)initWithInstanceName:(NSString*) instanceName
 {
-    return [self initWithInstanceName:instanceName networkClient:nil];
-}
-
-- (id)initWithInstanceName:(NSString*) instanceName networkClient: (id<AMPNetworkClient>) client
-{
     if ([AMPUtils isEmptyString:instanceName]) {
         instanceName = kAMPDefaultInstance;
     }
@@ -255,7 +245,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         self.eventUploadMaxBatchSize = kAMPEventUploadMaxBatchSize;
         self.eventUploadPeriodSeconds = kAMPEventUploadPeriodSeconds;
         self.minTimeBetweenSessionsMillis = kAMPMinTimeBetweenSessionsMillis;
-        self.networkClient = client;
         _backoffUploadBatchSize = self.eventUploadMaxBatchSize;
 
         _initializerQueue = [[NSOperationQueue alloc] init];


### PR DESCRIPTION
Hello! In the business I work we are required to only make connections using [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication), and, for that reason, we cannot use the SDK as is.

We have an internal proxy server that uses mTLS and talks to the "outside world", but, in order to use that, we need to inject our custom network client that enforces mTLS and uses our custom request encoding.

What do you think about the current implementation? I made it in a way that it won't break the existing API. The Android version of this PR is [Android #187](https://github.com/amplitude/Amplitude-Android/pull/187).