### PR TITLE
Adding ability to use custom event log url

### DIFF
--- a/Amplitude/Amplitude.h
+++ b/Amplitude/Amplitude.h
@@ -157,6 +157,15 @@
 - (void)initializeApiKey:(NSString*) apiKey userId:(NSString*) userId;
 
 
+/**
+ Overrides the default URL provided by kAMPEventLogUrl.
+ 
+ The main purpose is to offer a way for user to adopt a custom server or proxy to ingest the events
+ 
+ @param urlString The custom url to be used for sending events.
+ */
+- (void)useCustomEventLogURL: (NSString *)urlString;
+
 /**-----------------------------------------------------------------------------
  * @name Logging Events
  * -----------------------------------------------------------------------------

--- a/AmplitudeTests/Amplitude+Test.h
+++ b/AmplitudeTests/Amplitude+Test.h
@@ -35,5 +35,5 @@
 - (id)unarchive:(NSString*)path;
 - (BOOL)archive:(id) obj toFile:(NSString*)path;
 - (long long)getLastEventTime;
-
+- (NSString *)resolvedEventLogUrl; // exposing the private method from Amplitude
 @end

--- a/AmplitudeTests/AmplitudeTests.m
+++ b/AmplitudeTests/AmplitudeTests.m
@@ -924,4 +924,18 @@
     XCTAssertEqualObjects([NSNumber numberWithBool:NO], [trackingOptions objectForKey:@"ip_address"]);
 }
 
+- (void)testCustomEventLogURL {
+    // ensure the private function is implemented in Amplitude
+    if (![self.amplitude respondsToSelector:@selector(resolvedEventLogUrl)]) {
+        XCTFail(@"method implementation [Amplitude resolvedEventLogUrl] is not found.");
+        return;
+    }
+    NSString *url = @"https://testing.api.somecompany.com/";
+    [self.amplitude useCustomEventLogURL:url];
+    XCTAssertEqual([self.amplitude resolvedEventLogUrl], url);
+    
+    // verify amplitude uses default url after removing customEventLogURL
+    [self.amplitude useCustomEventLogURL:nil];
+    XCTAssertEqual([self.amplitude resolvedEventLogUrl], kAMPEventLogUrl);
+}
 @end


### PR DESCRIPTION
Currently the framework enforces using "https://api.amplitude.com/" as the event log url. We'd like to add the ability to hit our internal proxy instead. 

This will allow us to massage the data first prior to sending to Amplitude, so that we're not leaking sensitive information, and are in compliance with our security protocol.