### PR TITLE
Fix end background tasks

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -895,7 +895,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         long numEvents = limit > 0 ? fminl(eventCount, limit) : eventCount;
         if (numEvents == 0) {
             self->_updatingCurrently = NO;
-            [self endBackgroundTaskIfNeeded];
             return;
         }
         NSMutableArray *events = [self.dbHelper getEvents:-1 limit:numEvents];
@@ -912,7 +911,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         if (error != nil) {
             AMPLITUDE_ERROR(@"ERROR: NSJSONSerialization error: %@", error);
             self->_updatingCurrently = NO;
-            [self endBackgroundTaskIfNeeded];
             return;
         }
 
@@ -923,7 +921,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
                 SAFE_ARC_RELEASE(eventsString);
             }
             self->_updatingCurrently = NO;
-            [self endBackgroundTaskIfNeeded];
             return;
         }
 
@@ -1176,6 +1173,8 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         [self->_dbHelper insertOrReplaceKeyLongValue:OPT_OUT value:[NSNumber numberWithBool:self->_optOut]];
         [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:[NSNumber numberWithLongLong:self->_sessionId]];
         [self->_dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:[NSNumber numberWithLongLong:self->_lastEventTime]];
+
+        [self endBackgroundTaskIfNeeded];
     }];
 }
 


### PR DESCRIPTION
Making some modifications to ichina's PR: https://github.com/amplitude/Amplitude-iOS/pull/186
Instead of calling `endBackgroundTasksIfNeeded` in every early return in the upload method, just call it one time at the very end of the `onEnterBackground` handler

https://developer.apple.com/library/archive/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html

Tested in demo app, made sure that the `endBackgroundTasksIfNeeded` gets called after flushing or if no events are queued when going into background