### PR TITLE
Wrap the NSLogs so that we can suppress logs when not in debug mode

### DIFF
--- a/Amplitude-iOS.podspec
+++ b/Amplitude-iOS.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name                   = "Amplitude-iOS"
-  s.version                = "4.8.0"
+  s.version                = "4.8.1"
   s.summary                = "Amplitude mobile analytics iOS SDK."
   s.homepage               = "https://amplitude.com"
   s.license                = { :type => "MIT" }
   s.author                 = { "Amplitude" => "dev@amplitude.com" }
-  s.source                 = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v4.8.0" }
+  s.source                 = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v4.8.1" }
   s.ios.deployment_target  = '8.0'
   s.tvos.deployment_target = '9.0'
   s.source_files           = 'Amplitude/*.{h,m}', 'Amplitude/SSLCertificatePinning/*.{h,m}'

--- a/Amplitude/AMPConstants.m
+++ b/Amplitude/AMPConstants.m
@@ -4,7 +4,7 @@
 #import "AMPConstants.h"
 
 NSString *const kAMPLibrary = @"amplitude-ios";
-NSString *const kAMPVersion = @"4.7.1";
+NSString *const kAMPVersion = @"4.8.1";
 NSString *const kAMPEventLogDomain = @"api.amplitude.com";
 NSString *const kAMPEventLogUrl = @"https://api.amplitude.com/";
 NSString *const kAMPDefaultInstance = @"$default_instance";

--- a/Amplitude/AMPDatabaseHelper.m
+++ b/Amplitude/AMPDatabaseHelper.m
@@ -156,7 +156,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 
     dispatch_sync(_queue, ^() {
         if (sqlite3_open([self->_databasePath UTF8String], &self->_database) != SQLITE_OK) {
-            NSLog(@"Failed to open database");
+            AMPLITUDE_LOG(@"Failed to open database");
             sqlite3_close(self->_database);
             success = NO;
             return;
@@ -187,7 +187,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 
     dispatch_sync(_queue, ^() {
         if (sqlite3_open([self->_databasePath UTF8String], &self->_database) != SQLITE_OK) {
-            NSLog(@"Failed to open database");
+            AMPLITUDE_LOG(@"Failed to open database");
             sqlite3_close(self->_database);
             success = NO;
             return;
@@ -270,7 +270,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     }];
 
     if (!success) {
-        NSLog(@"upgrade with unknown oldVersion %d", oldVersion);
+        AMPLITUDE_LOG(@"upgrade with unknown oldVersion %d", oldVersion);
         return [self resetDB:NO];
     }
     return success;

--- a/Amplitude/AMPRevenue.m
+++ b/Amplitude/AMPRevenue.m
@@ -58,7 +58,7 @@
 - (BOOL)isValidRevenue
 {
     if (_price == nil) {
-        NSLog(@"Invalid revenue, need to set price field");
+        AMPLITUDE_LOG(@"Invalid revenue, need to set price field");
         return NO;
     }
     return YES;

--- a/Amplitude/AMPURLConnection.m
+++ b/Amplitude/AMPURLConnection.m
@@ -7,6 +7,18 @@
 //  Copyright (c) 2015 Amplitude. All rights reserved.
 //
 
+#ifndef AMPLITUDE_DEBUG
+#define AMPLITUDE_DEBUG 0
+#endif
+
+#ifndef AMPLITUDE_LOG
+#if AMPLITUDE_DEBUG
+#   define AMPLITUDE_LOG(fmt, ...) NSLog(fmt, ##__VA_ARGS__)
+#else
+#   define AMPLITUDE_LOG(...)
+#endif
+#endif
+
 #import "AMPURLConnection.h"
 #import "AMPARCMacros.h"
 #import "AMPConstants.h"
@@ -40,7 +52,7 @@
         NSString *certPath =  [[NSBundle bundleForClass:[self class]] pathForResource:certFilename ofType:@"der"];
         NSData *certData = SAFE_ARC_AUTORELEASE([[NSData alloc] initWithContentsOfFile:certPath]);
         if (certData == nil) {
-            NSLog(@"Failed to load a certificate");
+            AMPLITUDE_LOG(@"Failed to load a certificate");
             return;
         }
         [certs addObject:certData];
@@ -50,13 +62,13 @@
     [pins setObject:certs forKey:kAMPEventLogDomain];
 
     if (pins == nil) {
-        NSLog(@"Failed to pin a certificate");
+        AMPLITUDE_LOG(@"Failed to pin a certificate");
         return;
     }
 
     // Save the SSL pins so that our connection delegates automatically use them
     if ([ISPCertificatePinning setupSSLPinsUsingDictionnary:pins] != YES) {
-        NSLog(@"Failed to pin the certificates");
+        AMPLITUDE_LOG(@"Failed to pin the certificates");
         SAFE_ARC_RELEASE(pins);
         return;
     }

--- a/Amplitude/AMPURLSession.m
+++ b/Amplitude/AMPURLSession.m
@@ -7,6 +7,18 @@
 //  Copyright (c) 2017 Amplitude. All rights reserved.
 //
 
+#ifndef AMPLITUDE_DEBUG
+#define AMPLITUDE_DEBUG 0
+#endif
+
+#ifndef AMPLITUDE_LOG
+#if AMPLITUDE_DEBUG
+#   define AMPLITUDE_LOG(fmt, ...) NSLog(fmt, ##__VA_ARGS__)
+#else
+#   define AMPLITUDE_LOG(...)
+#endif
+#endif
+
 #import "AMPURLSession.h"
 #import "AMPARCMacros.h"
 #import "AMPConstants.h"
@@ -48,7 +60,7 @@
         NSString *certPath =  [[NSBundle bundleForClass:[self class]] pathForResource:certFilename ofType:@"der"];
         NSData *certData = SAFE_ARC_AUTORELEASE([[NSData alloc] initWithContentsOfFile:certPath]);
         if (certData == nil) {
-            NSLog(@"Failed to load a certificate");
+            AMPLITUDE_LOG(@"Failed to load a certificate");
             return;
         }
         [certs addObject:certData];
@@ -58,13 +70,13 @@
     [pins setObject:certs forKey:kAMPEventLogDomain];
 
     if (pins == nil) {
-        NSLog(@"Failed to pin a certificate");
+        AMPLITUDE_LOG(@"Failed to pin a certificate");
         return;
     }
 
     // Save the SSL pins so that our connection delegates automatically use them
     if ([ISPCertificatePinning setupSSLPinsUsingDictionnary:pins] != YES) {
-        NSLog(@"Failed to pin the certificates");
+        AMPLITUDE_LOG(@"Failed to pin the certificates");
         SAFE_ARC_RELEASE(pins);
         return;
     }

--- a/Amplitude/SSLCertificatePinning/ISPCertificatePinning.m
+++ b/Amplitude/SSLCertificatePinning/ISPCertificatePinning.m
@@ -7,6 +7,31 @@
 //  Copyright (c) 2014 iSEC Partners. All rights reserved.
 //
 
+#ifndef AMPLITUDE_DEBUG
+#define AMPLITUDE_DEBUG 0
+#endif
+
+#ifndef AMPLITUDE_LOG
+#if AMPLITUDE_DEBUG
+#   define AMPLITUDE_LOG(fmt, ...) NSLog(fmt, ##__VA_ARGS__)
+#else
+#   define AMPLITUDE_LOG(...)
+#endif
+#endif
+
+#ifndef AMPLITUDE_LOG_ERRORS
+#define AMPLITUDE_LOG_ERRORS 1
+#endif
+
+#ifndef AMPLITUDE_ERROR
+#if AMPLITUDE_LOG_ERRORS
+#   define AMPLITUDE_ERROR(fmt, ...) NSLog(fmt, ##__VA_ARGS__)
+#else
+#   define AMPLITUDE_ERROR(...)
+#endif
+#endif
+
+
 #import "ISPCertificatePinning.h"
 
 
@@ -30,7 +55,7 @@
                                                                   options:0
                                                                     error:&error];
     if (plistData == nil) {
-        NSLog(@"Error serializing plist: %@", error);
+        AMPLITUDE_ERROR(@"Error serializing plist: %@", error);
         return NO;
     }
 
@@ -39,7 +64,7 @@
     if ([plistData writeToFile:[@PINNED_KEYS_FILE_PATH stringByExpandingTildeInPath]
                        options:NSDataWritingAtomic
                          error:&writeError] == NO) {
-        NSLog(@"Error saving plist to the filesystem: %@", writeError);
+        AMPLITUDE_ERROR(@"Error saving plist to the filesystem: %@", writeError);
         return NO;
     }
 
@@ -55,7 +80,7 @@
     // Deserialize the plist that contains our SSL pins
     NSDictionary *SSLPinsDict = [NSDictionary dictionaryWithContentsOfFile:[@PINNED_KEYS_FILE_PATH stringByExpandingTildeInPath]];
     if (SSLPinsDict == nil) {
-        NSLog(@"Error accessing the SSL Pins plist at %@", @PINNED_KEYS_FILE_PATH);
+        AMPLITUDE_ERROR(@"Error accessing the SSL Pins plist at %@", @PINNED_KEYS_FILE_PATH);
         return NO;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
-## 4.7.1 (September 3, 2019)
+## 4.8.1 (September 19, 2019)
+
+* Suppress NSLogs for non-dev environments.
+
+## 4.8.0 (September 3, 2019)
 
 * Identify Macs for Mac Catalyst support.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An iOS SDK for tracking events and revenue to [Amplitude](https://www.amplitude.
 Please see our [installation guide](https://amplitude.zendesk.com/hc/en-us/articles/115002278527-iOS-SDK-Installation) for instructions on installing and using our iOS SDK.
 
 # Latest Version #
-[4.8.0 - Released on September 3, 2019](https://github.com/amplitude/Amplitude-iOS/releases/latest)
+[4.8.1 - Released on September 3, 2019](https://github.com/amplitude/Amplitude-iOS/releases/latest)
 [![Circle CI](https://circleci.com/gh/amplitude/Amplitude-iOS.svg?style=shield&circle-token=e1b2a7d2cd6dd64ac3643bc8cb2117c0ed5cbb75)](https://circleci.com/gh/amplitude/Amplitude-iOS/tree/master)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Amplitude-iOS.svg?style=flat)](http://cocoadocs.org/docsets/Amplitude-iOS/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)


### PR DESCRIPTION
Wrapping all NSLogs to allow suppressing it in non-dev environments. This will at least prevent crashes unless debug mode is turned on.

Related issue: https://github.com/amplitude/Amplitude-iOS/issues/204