### PR TITLE
Only try to end the backgroundTask if the app is in the background

### DIFF
--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -99,7 +99,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     AMPTrackingOptions *_trackingOptions;
     NSDictionary *_apiPropertiesTrackingOptions;
 
-    BOOL _runningInBackground;
     BOOL _inForeground;
     BOOL _offline;
 
@@ -1118,7 +1117,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (void)enterForeground
 {
-    _runningInBackground = NO;
     UIApplication *app = [self getSharedApplication];
     if (app == nil) {
         return;
@@ -1139,7 +1137,6 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (void)enterBackground
 {
-    _runningInBackground = YES;
     UIApplication *app = [self getSharedApplication];
     if (app == nil) {
         return;
@@ -1149,16 +1146,16 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     // Stop uploading
     [self endBackgroundTaskIfNeeded];
-    if (_runningInBackground) {
-        _uploadTaskID = [app beginBackgroundTaskWithExpirationHandler:^{
-            //Took too long, manually stop
-            [self endBackgroundTaskIfNeeded];
-        }];
-    }
+    _uploadTaskID = [app beginBackgroundTaskWithExpirationHandler:^{
+        //Took too long, manually stop
+        [self endBackgroundTaskIfNeeded];
+    }];
+
     [self runOnBackgroundQueue:^{
         self->_inForeground = NO;
         [self refreshSessionTime:now];
         [self uploadEventsWithLimit:0];
+        [self endBackgroundTaskIfNeeded];
     }];
 }
 

--- a/Amplitude/Amplitude.m
+++ b/Amplitude/Amplitude.m
@@ -873,6 +873,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         // Don't communicate with the server if the user has opted out.
         if ([self optOut] || self->_offline)  {
             self->_updatingCurrently = NO;
+            [self endBackgroundTaskIfNeeded];
             return;
         }
 
@@ -1155,17 +1156,17 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         self->_inForeground = NO;
         [self refreshSessionTime:now];
         [self uploadEventsWithLimit:0];
-        [self endBackgroundTaskIfNeeded];
     }];
 }
 
 - (void)endBackgroundTaskIfNeeded
 {
-    UIApplication *app = [self getSharedApplication];
-    if (app == nil) {
-        return;
-    }
     if (_uploadTaskID != UIBackgroundTaskInvalid) {
+        UIApplication *app = [self getSharedApplication];
+        if (app == nil) {
+            return;
+        }
+
         [app endBackgroundTask:_uploadTaskID];
         self->_uploadTaskID = UIBackgroundTaskInvalid;
     }


### PR DESCRIPTION
This attempts to address https://github.com/amplitude/Amplitude-iOS/issues/206

The fix is inspired by https://github.com/firebase/firebase-ios-sdk/pull/3837/files

For some reason, I can't manually trigger my previous backgroundTask error. Without repro steps, I'm walking in the dark a bit.

cc: @manan19