### PR TITLE
fix: wrong changelog date, should be October, 8 for version 4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 4.8.2 (September 19, 2019)
+## 4.8.2 (October 19, 2019)
 
 * Ensure background tasks are always ended and add safeguard before retrieving the app by checking for valid uploadTaskID
 


### PR DESCRIPTION
Hi, the new version released today, but seems like the change log release date hasn't been changed yet (Still 19, September). Made a little fix