### PR TITLE
Fix partial truncation for string with unicode (e.g. emoji)

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1550,7 +1550,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     if ([obj isKindOfClass:[NSString class]]) {
         obj = (NSString*)obj;
         if ([obj length] > kAMPMaxStringLength) {
-            obj = [obj substringToIndex:kAMPMaxStringLength];
+            obj = [obj substringWithRange: [obj rangeOfComposedCharacterSequencesForRange: NSMakeRange(0, kAMPMaxStringLength)]];
         }
     } else if ([obj isKindOfClass:[NSArray class]]) {
         NSMutableArray *arr = [NSMutableArray array];


### PR DESCRIPTION
- Use rangeOfComposedCharacterSequencesForRange to avoid bad truncation

Test:
- Repro it with a lot emojis
- Verified the fix and saw no exceptions thrown