### PR TITLE
Fix Swift package manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,7 @@ let package = Package(
     targets: [
         .target(
             name: "Amplitude",
-            path: "Sources",
             exclude: [],
-            sources: ["Amplitude", "Amplitude/"],
-            publicHeadersPath: "Amplitude"),
+            publicHeadersPath: "."),
     ]
 )


### PR DESCRIPTION
When adding Amplitude as a SwiftPM dependency to my project, it worked fine in Xcode 11.3 but started to fail in 11.4 BETA due to it not finding the sources. This fix works with both versions of Xcode.