### PR TITLE
Add AMPLITUDE_LOCATION_TRACKING preprocessor guard around location tracking code

### DIFF
--- a/Amplitude/AMPLocationManagerDelegate.h
+++ b/Amplitude/AMPLocationManagerDelegate.h
@@ -1,6 +1,12 @@
 //
 //  AMPLocationManagerDelegate.h
 
+#ifndef AMPLITUDE_LOCATION_TRACKING
+#define AMPLITUDE_LOCATION_TRACKING 1
+#endif
+
+#if AMPLITUDE_LOCATION_TRACKING
+
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
 
@@ -13,3 +19,5 @@
 - (void)locationManager:(CLLocationManager*) manager didChangeAuthorizationStatus:(CLAuthorizationStatus) status;
 
 @end
+
+#endif

--- a/Amplitude/AMPLocationManagerDelegate.m
+++ b/Amplitude/AMPLocationManagerDelegate.m
@@ -1,6 +1,12 @@
 //
 //  AMPLocationManagerDelegate.m
 
+#ifndef AMPLITUDE_LOCATION_TRACKING
+#define AMPLITUDE_LOCATION_TRACKING 1
+#endif
+
+#if AMPLITUDE_LOCATION_TRACKING
+
 #import "AMPLocationManagerDelegate.h"
 #import "Amplitude.h"
 
@@ -30,3 +36,5 @@
 }
 
 @end
+
+#endif


### PR DESCRIPTION
Duplicate of #194 which was closed without merging with no comment on why.  Adding this code should allow users to silence the warnings from App Store Connect mentioned in #168.

cc members @blazzy who created #194 and @djih who commented on it.