### PR TITLE
iOS 14 IDFA rework

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -369,24 +369,24 @@
 		12C9730F24108DFF00E9CDDB /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				12C9731824108DFF00E9CDDB /* BaseTestCase.h */,
+				12C9731E24108DFF00E9CDDB /* BaseTestCase.m */,
+				12C9731924108DFF00E9CDDB /* Amplitude+Test.h */,
+				12C9731224108DFF00E9CDDB /* Amplitude+Test.m */,
 				12C9731024108DFF00E9CDDB /* SSLPinningTests.m */,
 				12C9731124108DFF00E9CDDB /* DeviceInfoTests.m */,
-				12C9731224108DFF00E9CDDB /* Amplitude+Test.m */,
 				12C9731324108DFF00E9CDDB /* AmplitudeTests.m */,
 				12C9731424108DFF00E9CDDB /* AMPDatabaseHelperTests.m */,
 				12C9731524108DFF00E9CDDB /* RevenueTests.m */,
-				12C9731624108DFF00E9CDDB /* InvalidCertificationAuthority.der */,
 				12C9731724108DFF00E9CDDB /* SetupTests.m */,
-				12C9731824108DFF00E9CDDB /* BaseTestCase.h */,
-				12C9731924108DFF00E9CDDB /* Amplitude+Test.h */,
 				12C9731A24108DFF00E9CDDB /* AmplitudeiOSTests.m */,
 				12C9731B24108DFF00E9CDDB /* SessionTests.m */,
 				12C9731C24108DFF00E9CDDB /* TrackingOptionsTest.m */,
 				12C9731D24108DFF00E9CDDB /* IdentifyTests.m */,
-				12C9731E24108DFF00E9CDDB /* BaseTestCase.m */,
-				12C9731F24108DFF00E9CDDB /* Info.plist */,
 				12C9732024108DFF00E9CDDB /* AmplitudeTVOSTests.m */,
 				12C9732124108DFF00E9CDDB /* AMPLocationManagerDelegateTests.m */,
+				12C9731624108DFF00E9CDDB /* InvalidCertificationAuthority.der */,
+				12C9731F24108DFF00E9CDDB /* Info.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";

--- a/Sources/Amplitude/AMPDeviceInfo.h
+++ b/Sources/Amplitude/AMPDeviceInfo.h
@@ -33,7 +33,6 @@
 @property (readonly, strong, nonatomic) NSString *carrier;
 @property (readonly, strong, nonatomic) NSString *country;
 @property (readonly, strong, nonatomic) NSString *language;
-@property (readonly, strong, nonatomic) NSString *advertiserID;
 @property (readonly, strong, nonatomic) NSString *vendorID;
 
 + (NSString*) generateUUID;

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -57,7 +57,6 @@
 @synthesize carrier = _carrier;
 @synthesize country = _country;
 @synthesize language = _language;
-@synthesize advertiserID = _advertiserID;
 @synthesize vendorID = _vendorID;
 
 - (NSString*)appVersion {
@@ -138,28 +137,6 @@
     return _language;
 }
 
-- (NSString*)advertiserID {
-#if AMPLITUDE_IDFA_TRACKING
-    if (!_advertiserID) {
-#if !TARGET_OS_OSX
-        if ([[[UIDevice currentDevice] systemVersion] floatValue] >= (float) 6.0) {
-#endif
-            NSString *advertiserId = [AMPDeviceInfo getAdvertiserID:5];
-            if (advertiserId != nil &&
-                ![advertiserId isEqualToString:@"00000000-0000-0000-0000-000000000000"]) {
-                _advertiserID = advertiserId;
-            }
-        }
-#if !TARGET_OS_OSX
-    }
-#endif
-    return _advertiserID;
-
-#else
-    return nil;
-#endif
-}
-
 - (NSString*)vendorID {
     if (!_vendorID) {
 #if !TARGET_OS_OSX
@@ -175,38 +152,6 @@
     }
 #endif
     return _vendorID;
-}
-
-+ (NSString*)getAdvertiserID:(int) maxAttempts {
-#if AMPLITUDE_IDFA_TRACKING
-    Class ASIdentifierManager = NSClassFromString(@"ASIdentifierManager");
-    SEL sharedManager = NSSelectorFromString(@"sharedManager");
-    SEL advertisingIdentifier = NSSelectorFromString(@"advertisingIdentifier");
-    if (ASIdentifierManager && sharedManager && advertisingIdentifier) {
-        id (*imp1)(id, SEL) = (id (*)(id, SEL))[ASIdentifierManager methodForSelector:sharedManager];
-        id manager = nil;
-        NSUUID *adid = nil;
-        NSString *identifier = nil;
-        if (imp1) {
-            manager = imp1(ASIdentifierManager, sharedManager);
-        }
-        NSUUID* (*imp2)(id, SEL) = (NSUUID* (*)(id, SEL))[manager methodForSelector:advertisingIdentifier];
-        if (imp2) {
-            adid = imp2(manager, advertisingIdentifier);
-        }
-        if (adid) {
-            identifier = [adid UUIDString];
-        }
-        if (identifier == nil && maxAttempts > 0) {
-            // Try again every 5 seconds
-            [NSThread sleepForTimeInterval:5.0];
-            return [AMPDeviceInfo getAdvertiserID:maxAttempts - 1];
-        } else {
-            return identifier;
-        }
-    }
-#endif
-    return nil;
 }
 
 + (NSString*)getVendorID:(int) maxAttempts {

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -26,6 +26,8 @@
 #import "AMPRevenue.h"
 #import "AMPTrackingOptions.h"
 
+typedef NSString *_Nonnull (^AMPAdSupportBlock)(void);
+
 /**
  Amplitude iOS SDK.
 
@@ -137,6 +139,22 @@
  2. You want to track your library as one of the data sources.
 */
 @property (nonatomic, copy, readwrite) NSString *libraryVersion;
+
+/**
+ * Sets a block to be called when IDFA / AdSupport identifier is created.
+ * This is to allow for apps that do not want ad tracking to pass App Store guidelines in certain categories while
+ * still allowing apps that do ad tracking to continue to function.  This block will be called repeatedly during
+ * the life of the application as IDFA is needed.
+ *
+ * This achieve the previous SDK behavior use the example as follows.  It assumes you've handled any setup
+ * and dialogs necessary to receive permissions from the user.
+ *
+ * Example:
+ *      amplitude.adSupportBlock = ^{
+ *          return [[ASIdentifierManager sharedManager] advertisingIdentifier];
+ *      }
+ */
+@property (nonatomic, strong, nullable) AMPAdSupportBlock adSupportBlock;
 
 #pragma mark - Methods
 

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -670,9 +670,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     NSMutableDictionary *apiProperties = [event valueForKey:@"api_properties"];
 
-    NSString* advertiserID = _deviceInfo.advertiserID;
-    if ([_appliedTrackingOptions shouldTrackIDFA] && advertiserID) {
-        [apiProperties setValue:advertiserID forKey:@"ios_idfa"];
+    if ([_appliedTrackingOptions shouldTrackIDFA]) {
+        NSString* advertiserID = [self getAdSupportID];
+        if (advertiserID != nil) {
+            [apiProperties setValue:advertiserID forKey:@"ios_idfa"];
+        }
     }
     NSString* vendorID = _deviceInfo.vendorID;
     if ([_appliedTrackingOptions shouldTrackIDFV] && vendorID) {
@@ -1456,7 +1458,20 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     _useAdvertisingIdForDeviceId = YES;
 }
 
-#pragma mark - Getters for device data
+#pragma mark - Getters/Setters for device data
+
+- (NSString*)getAdSupportID {
+    NSString *result = nil;
+    if (self.adSupportBlock != nil && [_appliedTrackingOptions shouldTrackIDFA]) {
+        result = self.adSupportBlock();
+    }
+    // IDFA access was denied or still in progress.
+    if ([result isEqualToString:@"00000000-0000-0000-0000-000000000000"]) {
+        result = nil;
+    }
+    return result;
+}
+
 - (NSString*)getDeviceId {
     return self.deviceId;
 }
@@ -1479,7 +1494,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 - (NSString*)_getDeviceId {
     NSString *deviceId = nil;
     if (_useAdvertisingIdForDeviceId && [_appliedTrackingOptions shouldTrackIDFA]) {
-        deviceId = _deviceInfo.advertiserID;
+        deviceId = [self getAdSupportID];
     }
 
     // return identifierForVendor

--- a/Tests/BaseTestCase.m
+++ b/Tests/BaseTestCase.m
@@ -27,6 +27,9 @@ NSString *const userId = @"userId";
     XCTAssertTrue([self.databaseHelper resetDB:NO]);
 
     [self.amplitude init];
+    AMPTrackingOptions *opts = [AMPTrackingOptions options];
+    XCTAssertTrue([opts shouldTrackIDFA]);
+    [self.amplitude setTrackingOptions:opts];
     self.amplitude.sslPinningEnabled = NO;
 }
 

--- a/Tests/DeviceInfoTests.m
+++ b/Tests/DeviceInfoTests.m
@@ -95,22 +95,6 @@
     XCTAssertEqualObjects(@"English", _deviceInfo.language);
 }
 
-- (void)testAdvertiserID {
-    id mockDeviceInfo = OCMClassMock([AMPDeviceInfo class]);
-    [[mockDeviceInfo expect] getAdvertiserID:5];
-    XCTAssertEqualObjects(nil, _deviceInfo.advertiserID);
-    [mockDeviceInfo verify];
-    [mockDeviceInfo stopMocking];
-}
-
-- (void)testDisableIDFATracking {
-    id mockDeviceInfo = OCMClassMock([AMPDeviceInfo class]);
-    [[mockDeviceInfo reject] getAdvertiserID:5];
-    AMPDeviceInfo *newDeviceInfo = [[AMPDeviceInfo alloc] init:YES];
-    XCTAssertEqualObjects(nil, newDeviceInfo.advertiserID);
-    [mockDeviceInfo verify];
-    [mockDeviceInfo stopMocking];
-}
 
 #if TARGET_OS_IPHONE
 - (void)testVendorID {


### PR DESCRIPTION
- Made IDFA entirely external to the amplitude-ios library.
- Updated tests.
- Added documentation around the new adSupportBlock.