### PR TITLE
fix: Abort execution of completion block after dynamic config refresh completes if self is now nil (#288)

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -825,6 +825,9 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         __weak typeof(self) weakSelf = self;
         [[AMPConfigManager sharedInstance] refresh:^{
             __strong typeof(self) strongSelf = weakSelf;
+            if (strongSelf == nil) {
+                return;
+            }
             strongSelf->_serverUrl = [AMPConfigManager sharedInstance].ingestionEndpoint;
         }];
     }


### PR DESCRIPTION
Hopefully this meets your style guidelines; it's been a while since I coded Objective-C.