### PR TITLE
ci: change semantic-release bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        GIT_AUTHOR_NAME: amplitude-sdk-bot
+        GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        GIT_COMMITTER_NAME: amplitude-sdk-bot
+        GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
       run: |
         npx \
         -p lodash \
@@ -114,6 +118,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        GIT_AUTHOR_NAME: amplitude-sdk-bot
+        GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        GIT_COMMITTER_NAME: amplitude-sdk-bot
+        GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
       run: |
         npx \
         -p lodash \


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Changes `semantic-release` auto-updates repo bot from `@semantic-release-bot` to `amplitude-sdk-bot`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
