### PR TITLE
fix: Swift UserId and DeviceId setter

### DIFF
--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -554,6 +554,8 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 
  @param userId                  If your app has its own login system that you want to track users with, you can set the userId.
 
+ @param startNewSession         Terminates previous user session and creates a new one for the new user
+
  @see [Setting Custom UserIds](https://github.com/amplitude/Amplitude-iOS#setting-custom-user-ids)
  */
 - (void)setUserId:(nullable NSString *)userId startNewSession:(BOOL)startNewSession;

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -65,12 +65,12 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 /**
  Identifier for the current user.
  */
-@property (nonatomic, copy, readonly, nullable) NSString *userId;
+@property (nonatomic, copy, nullable) NSString *userId;
 
 /**
  Identifier for the current device.
  */
-@property (nonatomic, copy, readonly) NSString *deviceId;
+@property (nonatomic, copy) NSString *deviceId;
 
 /**
  Name of the SDK instance (ex: no name for default instance, or custom name for a named instance)

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -543,8 +543,6 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 /**
  Sets the userId and starts a new session.
 
-  **Note: this is deprecated** - please use `setUserId:(NSString*)userId startNewSession:(BOOL)startNewSession`
-
  @param userId                  If your app has its own login system that you want to track users with, you can set the userId.
  @see [Setting Custom UserIds](https://github.com/amplitude/Amplitude-iOS#setting-custom-user-ids)
  */

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -543,7 +543,7 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 /**
  Sets the userId and starts a new session.
 
-  **Note: this is deprecated** - please use `setUserId:(NSString*) userId startNewSession:(BOOL)startNewSession`
+  **Note: this is deprecated** - please use `setUserId:(NSString*)userId startNewSession:(BOOL)startNewSession`
 
  @param userId                  If your app has its own login system that you want to track users with, you can set the userId.
  @see [Setting Custom UserIds](https://github.com/amplitude/Amplitude-iOS#setting-custom-user-ids)

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -65,12 +65,12 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 /**
  Identifier for the current user.
  */
-@property (nonatomic, copy, nullable) NSString *userId;
+@property (nonatomic, copy, readonly, nullable) NSString *userId;
 
 /**
  Identifier for the current device.
  */
-@property (nonatomic, copy) NSString *deviceId;
+@property (nonatomic, copy, readonly) NSString *deviceId;
 
 /**
  Name of the SDK instance (ex: no name for default instance, or custom name for a named instance)

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -541,7 +541,10 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
  */
 
 /**
- Sets the userId.
+ Sets the userId and starts a new session.
+
+  **Note: this is deprecated** - please use `setUserId:(NSString*) userId startNewSession:(BOOL)startNewSession`
+
  @param userId                  If your app has its own login system that you want to track users with, you can set the userId.
  @see [Setting Custom UserIds](https://github.com/amplitude/Amplitude-iOS#setting-custom-user-ids)
  */
@@ -549,7 +552,7 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 - (void)setUserId:(nullable NSString *)userId;
 
 /**
- Sets the userId and starts a new session. The previous session for the previous user will be terminated and a new session will begin for the new user id.
+ Sets the userId. If startNewSession is true, the previous session for the previous user will be terminated and a new session will begin for the new userId.
 
  @param userId                  If your app has its own login system that you want to track users with, you can set the userId.
 

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -87,6 +87,8 @@
 @property (nonatomic, assign) long long sessionId;
 @property (nonatomic, assign) BOOL backoffUpload;
 @property (nonatomic, assign) int backoffUploadBatchSize;
+@property (nonatomic, copy, readwrite, nullable) NSString *userId;
+@property (nonatomic, copy, readwrite) NSString *deviceId;
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 @property (nonatomic, strong) AMPEventExplorer *eventExplorer;
 #endif

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -87,8 +87,6 @@
 @property (nonatomic, assign) long long sessionId;
 @property (nonatomic, assign) BOOL backoffUpload;
 @property (nonatomic, assign) int backoffUploadBatchSize;
-@property (nonatomic, copy, readwrite, nullable) NSString *userId;
-@property (nonatomic, copy, readwrite) NSString *deviceId;
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 @property (nonatomic, strong) AMPEventExplorer *eventExplorer;
 #endif

--- a/Sources/Amplitude/AmplitudePrivate.h
+++ b/Sources/Amplitude/AmplitudePrivate.h
@@ -11,8 +11,6 @@
 @interface Amplitude ()
 
 @property (nonatomic, copy, readwrite) NSString *apiKey;
-@property (nonatomic, copy, readwrite) NSString *userId;
-@property (nonatomic, copy, readwrite) NSString *deviceId;
 @property (nonatomic, copy, readwrite) NSString *instanceName;
 
 @end


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Move property declaration to `Amplitude.m` to fix usage in Swift
- Deprecate and document `setUserId(userId)` for `setUserId(userId, startNewSession)`
- Fixes #282 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
