### PR TITLE
build(cocoapods): Remove source from Podfile, run pod install

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
 project 'Amplitude'
 
 abstract_target 'shared' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,12 +5,12 @@ DEPENDENCIES:
   - OCMock (~> 3.2.1)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - OCMock
 
 SPEC CHECKSUMS:
   OCMock: 18c9b7e67d4c2770e95bb77a9cc1ae0c91fe3835
 
-PODFILE CHECKSUM: ad702276e534279d0fac23a14a2b469cc660ced4
+PODFILE CHECKSUM: c234af1832073dccffe31825daef96d6b0eb126c
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

This PR removes the `source` from the Podfile, so the new (well, not so new anymore :) cocoapods cdn is used as source instead of the old, quite massive Specs repository. I felt the need for this change because I wanted to contribute another bugfix and in order to do this, I had to run `pod install`, which took forever because cocoapods first had to clone the Specs repo. Doing this switch should remove some friction for other people who want to contribute.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No <!-- Yes or no -->
