### PR TITLE
fix(deprecation warnings): Fix deprecation warnings

### DIFF
--- a/Sources/Amplitude/AMPEventExplorer.m
+++ b/Sources/Amplitude/AMPEventExplorer.m
@@ -59,7 +59,7 @@
         
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC));
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
-            [[[AMPUtils getSharedApplication] keyWindow] addSubview:self.bubbleView];
+            [[AMPUtils getKeyWindow] addSubview:self.bubbleView];
         });
          
         [self.bubbleView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showInfoView)]];
@@ -70,7 +70,7 @@
 - (void)showInfoView {
     dispatch_async(dispatch_get_main_queue(), ^(void){
         if (self.bubbleView != nil) {
-            UIViewController *rootViewController = [[[AMPUtils getSharedApplication] keyWindow] rootViewController];
+            UIViewController *rootViewController = [[AMPUtils getKeyWindow] rootViewController];
             
             NSBundle *bundle = [NSBundle bundleForClass:[AMPInfoViewController class]];
             AMPInfoViewController *infoVC = [[AMPInfoViewController alloc] initWithNibName:@"AMPInfoViewController" bundle:bundle];

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -41,6 +41,7 @@
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 + (NSInteger)barBottomOffset;
 + (CGFloat)statusBarHeight;
++ (UIWindow *)getKeyWindow;
 #endif
 
 @end

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -174,7 +174,13 @@
     if (@available(iOS 13.0, *)) {
         statusBarSize = [[[[AMPUtils getKeyWindow] windowScene] statusBarManager] statusBarFrame].size;
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // Even with the availability check above, Xcode would still emit a deprecation warning here.
+        // Since there's no way that it could be reached on iOS's >= 13.0
+        // (where `[UIApplication statusBarFrame]` was deprecated), we simply ignore the warning.
         statusBarSize = [[AMPUtils getSharedApplication] statusBarFrame].size;
+#pragma clang diagnostic pop
     }
     return MIN(statusBarSize.width, statusBarSize.height);
 }

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -172,12 +172,30 @@
 + (CGFloat)statusBarHeight {
     CGSize statusBarSize;
     if (@available(iOS 13.0, *)) {
-        statusBarSize = [[[[AMPUtils getSharedApplication].keyWindow windowScene] statusBarManager] statusBarFrame].size;
+        statusBarSize = [[[[AMPUtils getKeyWindow] windowScene] statusBarManager] statusBarFrame].size;
     } else {
         statusBarSize = [[AMPUtils getSharedApplication] statusBarFrame].size;
     }
     return MIN(statusBarSize.width, statusBarSize.height);
 }
+
++ (UIWindow *)getKeyWindow {
+    if (@available(iOS 13.0, *)) {
+        for (UIWindow *window in [[AMPUtils getSharedApplication] windows]) {
+            if (window.isKeyWindow) { return window; }
+        }
+        return nil;
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // Even with the availability check above, Xcode would still emit a deprecation warning here.
+        // Since there's no way that it could be reached on iOS's >= 13.0
+        // (where `[UIApplication keyWindow]` was deprecated), we simply ignore the warning.
+        return [[AMPUtils getSharedApplication] keyWindow];
+#pragma clang diagnostic pop
+    }
+}
+
 #endif
 
 @end

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -188,7 +188,9 @@
 + (UIWindow *)getKeyWindow {
     if (@available(iOS 13.0, *)) {
         for (UIWindow *window in [[AMPUtils getSharedApplication] windows]) {
-            if (window.isKeyWindow) { return window; }
+            if ([window isKeyWindow]) {
+                return window;
+            }
         }
         return nil;
     } else {

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1647,7 +1647,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             NSData *inputData = [fileManager contentsAtPath:path];
             NSError *error = nil;
             if (inputData != nil) {
-                id data = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:inputData error:&error];
+                id data = [self unarchive:inputData error:&error];
                 if (error == nil) {
                     if (data != nil) {
                         return data;
@@ -1675,6 +1675,21 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 #endif
     return nil;
+}
+
+- (id)unarchive:(NSData *)data error:(NSError **)error {
+    if (@available(iOS 12, *)) {
+        return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // Even with the availability check above, Xcode would still emit a deprecation warning here.
+        // Since there's no way that it could be reached on iOS's >= 12.0
+        // (where `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData:error:]` was deprecated),
+        // we simply ignore the warning.
+        return [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:error];
+#pragma clang diagnostic pop
+    }
 }
 
 - (BOOL)archive:(id) obj toFile:(NSString*)path {

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1534,7 +1534,15 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 - (NSString*)md5HexDigest:(NSString*)input {
     const char* str = [input UTF8String];
     unsigned char result[CC_MD5_DIGEST_LENGTH];
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // As mentioned by @haoliu-amp in // https://github.com/amplitude/Amplitude-iOS/issues/250#issuecomment-655224554,
+    // > This crypto algorithm is used for our checksum field, actually you don't need to worry about the security concern for that.
+    // > However, we will see if we wanna switch it to SHA256.
+    // Based on this, we can silence the compile warning here until a fix is implemented.
     CC_MD5(str, (CC_LONG) strlen(str), result);
+#pragma clang diagnostic pop
 
     NSMutableString *ret = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH*2];
     for(int i = 0; i<CC_MD5_DIGEST_LENGTH; i++) {

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1686,13 +1686,13 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (id)unarchive:(NSData *)data error:(NSError **)error {
-    if (@available(iOS 12, *)) {
+    if (@available(iOS 12, tvOS 11.0, *)) {
         return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error];
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         // Even with the availability check above, Xcode would still emit a deprecation warning here.
-        // Since there's no way that it could be reached on iOS's >= 12.0
+        // Since there's no way that it could be reached on iOS's >= 12.0 or tvOS's >= 11.0
         // (where `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData:error:]` was deprecated),
         // we simply ignore the warning.
         return [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:error];
@@ -1701,7 +1701,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (BOOL)archive:(id) obj toFile:(NSString*)path {
-    if (@available(iOS 12, *)) {
+    if (@available(tvOS 11.0, iOS 12, *)) {
         NSError *archiveError = nil;
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError];
         if (archiveError != nil) {
@@ -1723,7 +1723,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         // Even with the availability check above, Xcode would still emit a deprecation warning here.
-        // Since there's no way that this path could be reached on iOS's >= 12.0
+        // Since there's no way that this path could be reached on iOS's >= 12.0 or tvOS's >= 11.0
         // (where `[NSKeyedArchiver archiveRootObject:toFile:]` was deprecated),
         // we simply ignore the warning.
         return [NSKeyedArchiver archiveRootObject:obj toFile:path];


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

This PR 
- fixes deprecation warnings for iOS 12.0 and 13.0, tvOS 11.0 
- adds a `diagnostic ignored` around the usage of the function `CC_MD5`, which was deprecated in iOS 13.0 but [is only used for the checksum field](https://github.com/amplitude/Amplitude-iOS/issues/250#issuecomment-655224554), thus it should be fine to silence the warning

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
