### PR TITLE
ci: appledoc release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         ruby-version: ["2.7.x"]
         node-version: ["12.x"]
     steps:
-    - name: Checkout
+    - name: Checkout Amplitude-iOS
       uses: actions/checkout@v2
     
     - name: Set Xcode 12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,18 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Checkout Amplitude-iOS gh-pages for building docs
+      uses: actions/checkout@v2
+      with:
+        ref: 'gh-pages'
+        path: 'Amplitude-iOS-gh-pages'
+
+    - name: Install appledoc
+      run: |
+        git clone git://github.com/tomaz/appledoc.git
+        cd appledoc/
+        sudo sh install-appledoc.sh
+
     - name: Semantic Release --dry-run
       if: ${{ github.event.inputs.dryRun == 'true'}}
       env:
@@ -131,7 +143,3 @@ jobs:
         -p @google/semantic-release-replace-plugin@1 \
         -p @semantic-release/exec@5 \
         semantic-release
-
-    - name: Generate docs
-      run: |
-        appledoc --project-name Amplitude --project-company "Amplitude Inc" --company-id com.amplitude --no-create-docset --output ./doc/ .

--- a/release.config.js
+++ b/release.config.js
@@ -55,6 +55,7 @@ module.exports = {
     }],
     ["@semantic-release/exec", {
       "publishCmd": "pod trunk push Amplitude.podspec",
+      "successCmd": "appledoc --exit-threshold 2  --project-name Amplitude --project-company \"Amplitude Inc\" --company-id com.amplitude --no-create-docset --output ./doc/ . && rsync -av doc/html/*  Amplitude-iOS-gh-pages/ && cd Amplitude-iOS-gh-pages && git commit -am '${nextRelease.version}' && git push"
     }],
   ],
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Fixes release process to correctly generate appledocs and push to `gh-pages` branch
- Tested on fork


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
