### PR TITLE
ci: Podfile validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,7 @@ jobs:
           test
     
     - name: Validate Podfile
-      run: |
-        pod spec lint
+      run: pod lib lint
 
     - name: Setup Node.js
       uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
         bundle install
         pod install
 
+    - name: Validate Podfile
+      run: pod lib lint
+
     - name: iOS Tests
       run: |    
         xcodebuild test \


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Use `pod lib lint` instead of `pod spec lint`
  - `pod lib lint` validates local code, while `pod spec lint` validates remote code associated with current tag
  - Example: The release of `v7.1.1` had a false positive validation because `pod spec lint` was validating `v7.1.0` instead
- Add podfile validation to `test.yml`
- Current CI check will fail because of warnings that will be fixed in future PR

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
