### PR TITLE
style(blocks): Remove `()` and `(void)` before block declarations

### DIFF
--- a/Sources/Amplitude/AMPDatabaseHelper.m
+++ b/Sources/Amplitude/AMPDatabaseHelper.m
@@ -153,7 +153,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         
         __block BOOL success = YES;
         
-        dispatch_sync(_queue, ^() {
+        dispatch_sync(_queue, ^{
             if (sqlite3_open([self->_databasePath UTF8String], &self->_database) != SQLITE_OK) {
                 AMPLITUDE_LOG(@"Failed to open database");
                 sqlite3_close(self->_database);
@@ -189,7 +189,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         
         __block BOOL success = YES;
         
-        dispatch_sync(_queue, ^() {
+        dispatch_sync(_queue, ^{
             if (sqlite3_open([self->_databasePath UTF8String], &self->_database) != SQLITE_OK) {
                 AMPLITUDE_LOG(@"Failed to open database");
                 sqlite3_close(self->_database);

--- a/Sources/Amplitude/AMPEventExplorer.m
+++ b/Sources/Amplitude/AMPEventExplorer.m
@@ -46,7 +46,7 @@
 }
 
 - (void)showBubbleView {
-    dispatch_async(dispatch_get_main_queue(), ^(void){
+    dispatch_async(dispatch_get_main_queue(), ^{
         CGRect screenRect = [[UIScreen mainScreen] bounds];
         CGFloat screenWidth = screenRect.size.width;
         CGFloat screenHeight = screenRect.size.height;
@@ -58,7 +58,7 @@
                                                                            35)];
         
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC));
-        dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
+        dispatch_after(popTime, dispatch_get_main_queue(), ^{
             [[AMPUtils getKeyWindow] addSubview:self.bubbleView];
         });
          
@@ -68,7 +68,7 @@
 }
 
 - (void)showInfoView {
-    dispatch_async(dispatch_get_main_queue(), ^(void){
+    dispatch_async(dispatch_get_main_queue(), ^{
         if (self.bubbleView != nil) {
             UIViewController *rootViewController = [[AMPUtils getKeyWindow] rootViewController];
             

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -461,7 +461,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         // Release build
         #if !RELEASE
         if (self.showEventExplorer) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^(void) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
 
                 if (self.eventExplorer == nil) {
                     self.eventExplorer = [[AMPEventExplorer alloc] initWithInstanceName:self.instanceName];


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

This PR unifies the declarations of blocks without input parameters and without return value.
They are now all declared like this `^{` instead of `^(){` or `^(void){`. This is consistent with
the majority of declarations for blocks like this in the codebase.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
