### PR TITLE
style(whitespaces): Improve whitespace consistency

### DIFF
--- a/Sources/Amplitude/AMPConfigManager.h
+++ b/Sources/Amplitude/AMPConfigManager.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AMPConfigManager : NSObject
 
-@property (nonatomic, strong, readonly) NSString* ingestionEndpoint;
+@property (nonatomic, strong, readonly) NSString *ingestionEndpoint;
 
 + (instancetype)sharedInstance;
 - (void)refresh:(void(^)(void))completionHandler;

--- a/Sources/Amplitude/AMPConfigManager.m
+++ b/Sources/Amplitude/AMPConfigManager.m
@@ -26,7 +26,7 @@
 
 @interface AMPConfigManager()
 
-@property (nonatomic, strong, readwrite) NSString* ingestionEndpoint;
+@property (nonatomic, strong, readwrite) NSString *ingestionEndpoint;
 
 @end
 

--- a/Sources/Amplitude/AMPConfigManager.m
+++ b/Sources/Amplitude/AMPConfigManager.m
@@ -61,7 +61,7 @@
             if (urlString) {
                 NSString *ingestionEndpoint = [NSString stringWithFormat:@"https://%@", urlString];
                 
-                NSURL *url = [NSURL URLWithString: ingestionEndpoint];
+                NSURL *url = [NSURL URLWithString:ingestionEndpoint];
                 if (url && url.scheme && url.host) {
                     self.ingestionEndpoint = ingestionEndpoint;
                 }

--- a/Sources/Amplitude/AMPConfigManager.m
+++ b/Sources/Amplitude/AMPConfigManager.m
@@ -24,7 +24,7 @@
 #import "AMPConfigManager.h"
 #import "AMPConstants.h"
 
-@interface AMPConfigManager()
+@interface AMPConfigManager ()
 
 @property (nonatomic, strong, readwrite) NSString *ingestionEndpoint;
 

--- a/Sources/Amplitude/AMPDatabaseHelper.h
+++ b/Sources/Amplitude/AMPDatabaseHelper.h
@@ -35,8 +35,8 @@
 - (BOOL)resetDB:(BOOL) deleteDB;
 - (BOOL)deleteDB;
 
-- (BOOL)addEvent:(NSString *) event;
-- (BOOL)addIdentify:(NSString *) identify;
+- (BOOL)addEvent:(NSString *)event;
+- (BOOL)addIdentify:(NSString *)identify;
 - (NSMutableArray *)getEvents:(long long)upToId limit:(long long)limit;
 - (NSMutableArray *)getIdentifys:(long long)upToId limit:(long long)limit;
 - (int)getEventCount;

--- a/Sources/Amplitude/AMPDatabaseHelper.h
+++ b/Sources/Amplitude/AMPDatabaseHelper.h
@@ -27,18 +27,18 @@
 
 @property (nonatomic, strong, readonly) NSString *databasePath;
 
-+ (AMPDatabaseHelper*)getDatabaseHelper;
-+ (AMPDatabaseHelper*)getDatabaseHelper:(NSString*)instanceName;
++ (AMPDatabaseHelper *)getDatabaseHelper;
++ (AMPDatabaseHelper *)getDatabaseHelper:(NSString *)instanceName;
 - (BOOL)createTables;
 - (BOOL)dropTables;
 - (BOOL)upgrade:(int) oldVersion newVersion:(int)newVersion;
 - (BOOL)resetDB:(BOOL) deleteDB;
 - (BOOL)deleteDB;
 
-- (BOOL)addEvent:(NSString*) event;
-- (BOOL)addIdentify:(NSString*) identify;
-- (NSMutableArray*)getEvents:(long long)upToId limit:(long long)limit;
-- (NSMutableArray*)getIdentifys:(long long)upToId limit:(long long)limit;
+- (BOOL)addEvent:(NSString *) event;
+- (BOOL)addIdentify:(NSString *) identify;
+- (NSMutableArray *)getEvents:(long long)upToId limit:(long long)limit;
+- (NSMutableArray *)getIdentifys:(long long)upToId limit:(long long)limit;
 - (int)getEventCount;
 - (int)getIdentifyCount;
 - (int)getTotalEventCount;
@@ -49,9 +49,9 @@
 - (long long)getNthEventId:(long long)n;
 - (long long)getNthIdentifyId:(long long)n;
 
-- (BOOL)insertOrReplaceKeyValue:(NSString*)key value:(NSString*)value;
-- (BOOL)insertOrReplaceKeyLongValue:(NSString*)key value:(NSNumber*)value;
-- (NSString*)getValue:(NSString*)key;
-- (NSNumber*)getLongValue:(NSString*)key;
+- (BOOL)insertOrReplaceKeyValue:(NSString *)key value:(NSString *)value;
+- (BOOL)insertOrReplaceKeyLongValue:(NSString *)key value:(NSNumber *)value;
+- (NSString *)getValue:(NSString *)key;
+- (NSNumber *)getLongValue:(NSString *)key;
 
 @end

--- a/Sources/Amplitude/AMPDatabaseHelper.h
+++ b/Sources/Amplitude/AMPDatabaseHelper.h
@@ -31,8 +31,8 @@
 + (AMPDatabaseHelper *)getDatabaseHelper:(NSString *)instanceName;
 - (BOOL)createTables;
 - (BOOL)dropTables;
-- (BOOL)upgrade:(int) oldVersion newVersion:(int)newVersion;
-- (BOOL)resetDB:(BOOL) deleteDB;
+- (BOOL)upgrade:(int)oldVersion newVersion:(int)newVersion;
+- (BOOL)resetDB:(BOOL)deleteDB;
 - (BOOL)deleteDB;
 
 - (BOOL)addEvent:(NSString *)event;

--- a/Sources/Amplitude/AMPDatabaseHelper.m
+++ b/Sources/Amplitude/AMPDatabaseHelper.m
@@ -218,7 +218,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 }
 
 // Assumes db is already opened
-- (BOOL)execSQLString:(sqlite3 *) db SQLString:(NSString *) SQLString {
+- (BOOL)execSQLString:(sqlite3 *)db SQLString:(NSString *)SQLString {
     @try {
         char *errMsg;
         if (sqlite3_exec(db, [SQLString UTF8String], NULL, NULL, &errMsg) != SQLITE_OK) {
@@ -411,7 +411,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return events;
 }
 
-- (BOOL)insertOrReplaceKeyValue:(NSString *)key value:(NSString *) value {
+- (BOOL)insertOrReplaceKeyValue:(NSString *)key value:(NSString *)value {
     if (value == nil) return [self deleteKeyFromTable:STORE_TABLE_NAME key:key];
     return [self insertOrReplaceKeyValueToTable:STORE_TABLE_NAME key:key value:value];
 }

--- a/Sources/Amplitude/AMPDatabaseHelper.m
+++ b/Sources/Amplitude/AMPDatabaseHelper.m
@@ -78,11 +78,11 @@ static NSString *const DELETE_KEY = @"DELETE FROM %@ WHERE %@ = ?;";
 static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 
 
-+ (AMPDatabaseHelper*)getDatabaseHelper {
++ (AMPDatabaseHelper *)getDatabaseHelper {
     return [AMPDatabaseHelper getDatabaseHelper:nil];
 }
 
-+ (AMPDatabaseHelper*)getDatabaseHelper:(NSString*)instanceName {
++ (AMPDatabaseHelper *)getDatabaseHelper:(NSString *)instanceName {
     static NSMutableDictionary *_instances = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -109,7 +109,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return [self initWithInstanceName:nil];
 }
 
-- (instancetype)initWithInstanceName:(NSString*)instanceName {
+- (instancetype)initWithInstanceName:(NSString *)instanceName {
     if ([AMPUtils isEmptyString:instanceName]) {
         instanceName = kAMPDefaultInstance;
     }
@@ -177,7 +177,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
  * This version also handles preparing a statement from SQL string, and finalizing it as well.
  * Returns YES if successfully opened database and prepared statement, else NO.
  */
-- (BOOL)inDatabaseWithStatement:(NSString*)SQLString block:(void (^)(sqlite3_stmt *stmt))block
+- (BOOL)inDatabaseWithStatement:(NSString *)SQLString block:(void (^)(sqlite3_stmt *stmt))block
 {
     @try {
         // check that the block doesn't isn't calling inDatabase itself, which would lead to a deadlock
@@ -218,7 +218,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 }
 
 // Assumes db is already opened
-- (BOOL)execSQLString:(sqlite3*) db SQLString:(NSString*) SQLString {
+- (BOOL)execSQLString:(sqlite3 *) db SQLString:(NSString *) SQLString {
     @try {
         char *errMsg;
         if (sqlite3_exec(db, [SQLString UTF8String], NULL, NULL, &errMsg) != SQLITE_OK) {
@@ -326,15 +326,15 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return YES;
 }
 
-- (BOOL)addEvent:(NSString*)event {
+- (BOOL)addEvent:(NSString *)event {
     return [self addEventToTable:EVENT_TABLE_NAME event:event];
 }
 
-- (BOOL)addIdentify:(NSString*)identifyEvent {
+- (BOOL)addIdentify:(NSString *)identifyEvent {
     return [self addEventToTable:IDENTIFY_TABLE_NAME event:identifyEvent];
 }
 
-- (BOOL)addEventToTable:(NSString*)table event:(NSString*)event {
+- (BOOL)addEventToTable:(NSString *)table event:(NSString *)event {
     __block BOOL success = YES;
     NSString *insertSQL = [NSString stringWithFormat:INSERT_EVENT, table, EVENT_FIELD];
 
@@ -357,15 +357,15 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return success;
 }
 
-- (NSMutableArray*)getEvents:(long long)upToId limit:(long long)limit {
+- (NSMutableArray *)getEvents:(long long)upToId limit:(long long)limit {
     return [self getEventsFromTable:EVENT_TABLE_NAME upToId:upToId limit:limit];
 }
 
-- (NSMutableArray*)getIdentifys:(long long)upToId limit:(long long)limit {
+- (NSMutableArray *)getIdentifys:(long long)upToId limit:(long long)limit {
     return [self getEventsFromTable:IDENTIFY_TABLE_NAME upToId:upToId limit:limit];
 }
 
-- (NSMutableArray*)getEventsFromTable:(NSString*)table upToId:(long long)upToId limit:(long long)limit {
+- (NSMutableArray *)getEventsFromTable:(NSString *)table upToId:(long long)upToId limit:(long long)limit {
     __block NSMutableArray *events = [[NSMutableArray alloc] init];
     NSString *querySQL;
     if (upToId > 0 && limit > 0) {
@@ -383,7 +383,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
             long long eventId = sqlite3_column_int64(stmt, 0);
 
             // need to handle null events saved to database
-            const char *rawEventString = (const char*)sqlite3_column_text(stmt, 1);
+            const char *rawEventString = (const char *)sqlite3_column_text(stmt, 1);
             if (rawEventString == NULL) {
                 AMPLITUDE_LOG(@"Ignoring NULL event string for event id %lld from table %@", eventId, table);
                 continue;
@@ -411,17 +411,17 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return events;
 }
 
-- (BOOL)insertOrReplaceKeyValue:(NSString*)key value:(NSString*) value {
+- (BOOL)insertOrReplaceKeyValue:(NSString *)key value:(NSString *) value {
     if (value == nil) return [self deleteKeyFromTable:STORE_TABLE_NAME key:key];
     return [self insertOrReplaceKeyValueToTable:STORE_TABLE_NAME key:key value:value];
 }
 
-- (BOOL)insertOrReplaceKeyLongValue:(NSString *)key value:(NSNumber*)value {
+- (BOOL)insertOrReplaceKeyLongValue:(NSString *)key value:(NSNumber *)value {
     if (value == nil) return [self deleteKeyFromTable:LONG_STORE_TABLE_NAME key:key];
     return [self insertOrReplaceKeyValueToTable:LONG_STORE_TABLE_NAME key:key value:value];
 }
 
-- (BOOL)insertOrReplaceKeyValueToTable:(NSString*)table key:(NSString*)key value:(NSObject*)value {
+- (BOOL)insertOrReplaceKeyValueToTable:(NSString *)table key:(NSString *)key value:(NSObject *)value {
     __block BOOL success = YES;
     NSString *insertSQL = [NSString stringWithFormat:INSERT_OR_REPLACE_KEY_VALUE, table, KEY_FIELD, VALUE_FIELD];
 
@@ -430,7 +430,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         if ([table isEqualToString:STORE_TABLE_NAME]) {
             success &= sqlite3_bind_text(stmt, 2, [(NSString *)value UTF8String], -1, SQLITE_STATIC) == SQLITE_OK;
         } else {
-            success &= sqlite3_bind_int64(stmt, 2, [(NSNumber*)value longLongValue]) == SQLITE_OK;
+            success &= sqlite3_bind_int64(stmt, 2, [(NSNumber *)value longLongValue]) == SQLITE_OK;
         }
 
         if (!success) {
@@ -450,7 +450,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return success;
 }
 
-- (BOOL) deleteKeyFromTable:(NSString*)table key:(NSString*)key {
+- (BOOL) deleteKeyFromTable:(NSString *)table key:(NSString *)key {
     __block BOOL success = YES;
     NSString *deleteSQL = [NSString stringWithFormat:DELETE_KEY, table, KEY_FIELD];
 
@@ -473,16 +473,16 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return success;
 }
 
-- (NSString*)getValue:(NSString*)key {
-    return (NSString*)[self getValueFromTable:STORE_TABLE_NAME key:key];
+- (NSString *)getValue:(NSString *)key {
+    return (NSString *)[self getValueFromTable:STORE_TABLE_NAME key:key];
 }
 
-- (NSNumber*)getLongValue:(NSString*)key
+- (NSNumber *)getLongValue:(NSString *)key
 {
-    return (NSNumber*)[self getValueFromTable:LONG_STORE_TABLE_NAME key:key];
+    return (NSNumber *)[self getValueFromTable:LONG_STORE_TABLE_NAME key:key];
 }
 
-- (NSObject*)getValueFromTable:(NSString*)table key:(NSString*)key {
+- (NSObject *)getValueFromTable:(NSString *)table key:(NSString *)key {
     __block NSObject *value = nil;
     NSString *querySQL = [NSString stringWithFormat:GET_VALUE, KEY_FIELD, VALUE_FIELD, table, KEY_FIELD];
 
@@ -495,7 +495,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
         if (sqlite3_step(stmt) == SQLITE_ROW) {
             if (sqlite3_column_type(stmt, 1) != SQLITE_NULL) {
                 if ([table isEqualToString:STORE_TABLE_NAME]) {
-                    value = [[NSString alloc] initWithUTF8String:(char*)sqlite3_column_text(stmt, 1)];
+                    value = [[NSString alloc] initWithUTF8String:(char *)sqlite3_column_text(stmt, 1)];
                 } else {
                     long long longlongValue = sqlite3_column_int64(stmt, 1);
                     value = [[NSNumber alloc] initWithLongLong:longlongValue];
@@ -521,7 +521,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return [self getEventCount] + [self getIdentifyCount];
 }
 
-- (int)getEventCountFromTable:(NSString*)table {
+- (int)getEventCountFromTable:(NSString *)table {
     __block int count = 0;
     NSString *querySQL = [NSString stringWithFormat:COUNT_EVENTS, table];
 
@@ -544,7 +544,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return [self removeEventsFromTable:IDENTIFY_TABLE_NAME maxId:maxIdentifyId];
 }
 
-- (BOOL)removeEventsFromTable:(NSString*)table maxId:(long long)maxId {
+- (BOOL)removeEventsFromTable:(NSString *)table maxId:(long long)maxId {
     __block BOOL success = YES;
 
     success &= [self inDatabase:^(sqlite3 *db) {
@@ -563,7 +563,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return [self removeEventFromTable:IDENTIFY_TABLE_NAME eventId:identifyId];
 }
 
-- (BOOL)removeEventFromTable:(NSString*)table eventId:(long long)eventId {
+- (BOOL)removeEventFromTable:(NSString *)table eventId:(long long)eventId {
     __block BOOL success = YES;
 
     success &= [self inDatabase:^(sqlite3 *db) {
@@ -582,7 +582,7 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
     return [self getNthEventIdFromTable:IDENTIFY_TABLE_NAME n:n];
 }
 
-- (long long)getNthEventIdFromTable:(NSString*)table n:(long long)n {
+- (long long)getNthEventIdFromTable:(NSString *)table n:(long long)n {
     __block long long eventId = -1;
     NSString *querySQL = [NSString stringWithFormat:GET_NTH_EVENT_ID, ID_FIELD, table, n-1];
 

--- a/Sources/Amplitude/AMPDeviceInfo.h
+++ b/Sources/Amplitude/AMPDeviceInfo.h
@@ -35,6 +35,6 @@
 @property (readonly, strong, nonatomic) NSString *language;
 @property (readonly, strong, nonatomic) NSString *vendorID;
 
-+ (NSString*) generateUUID;
++ (NSString *) generateUUID;
 
 @end

--- a/Sources/Amplitude/AMPDeviceInfo.h
+++ b/Sources/Amplitude/AMPDeviceInfo.h
@@ -35,6 +35,6 @@
 @property (readonly, strong, nonatomic) NSString *language;
 @property (readonly, strong, nonatomic) NSString *vendorID;
 
-+ (NSString *) generateUUID;
++ (NSString *)generateUUID;
 
 @end

--- a/Sources/Amplitude/AMPDeviceInfo.h
+++ b/Sources/Amplitude/AMPDeviceInfo.h
@@ -23,7 +23,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface AMPDeviceInfo: NSObject
+@interface AMPDeviceInfo : NSObject
 
 @property (readonly, strong, nonatomic) NSString *appVersion;
 @property (readonly, strong, nonatomic) NSString *osName;

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -392,10 +392,10 @@
     }
 
     // Map msgbuffer to interface message structure
-    interfaceMsgStruct = (struct if_msghdr *) msgBuffer;
+    interfaceMsgStruct = (struct if_msghdr *)msgBuffer;
 
     // Map to link-level socket structure
-    socketStruct = (struct sockaddr_dl *) (interfaceMsgStruct + 1);
+    socketStruct = (struct sockaddr_dl *)(interfaceMsgStruct + 1);
 
     // Copy link layer address data in socket structure to an array
     memcpy(&macAddress, socketStruct->sdl_data + socketStruct->sdl_nlen, 6);

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -48,7 +48,7 @@
 @end
 
 @implementation AMPDeviceInfo {
-    NSObject* networkInfo;
+    NSObject *networkInfo;
 }
 
 @synthesize appVersion = _appVersion;

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -154,7 +154,7 @@
     return _vendorID;
 }
 
-+ (NSString *)getVendorID:(int) maxAttempts {
++ (NSString *)getVendorID:(int)maxAttempts {
 #if !TARGET_OS_OSX
     NSString *identifier = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
 #else

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -59,18 +59,18 @@
 @synthesize language = _language;
 @synthesize vendorID = _vendorID;
 
-- (NSString*)appVersion {
+- (NSString *)appVersion {
     if (!_appVersion) {
         _appVersion = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleShortVersionString"];
     }
     return _appVersion;
 }
 
-- (NSString*)osName {
+- (NSString *)osName {
     return kAMPOSName;
 }
 
-- (NSString*)osVersion {
+- (NSString *)osVersion {
     if (!_osVersion) {
         #if !TARGET_OS_OSX
         _osVersion = [[UIDevice currentDevice] systemVersion];
@@ -85,18 +85,18 @@
     return _osVersion;
 }
 
-- (NSString*)manufacturer {
+- (NSString *)manufacturer {
     return @"Apple";
 }
 
-- (NSString*)model {
+- (NSString *)model {
     if (!_model) {
         _model = [AMPDeviceInfo getDeviceModel];
     }
     return _model;
 }
 
-- (NSString*)carrier {
+- (NSString *)carrier {
     if (!_carrier) {
         Class CTTelephonyNetworkInfo = NSClassFromString(@"CTTelephonyNetworkInfo");
         SEL subscriberCellularProvider = NSSelectorFromString(@"subscriberCellularProvider");
@@ -108,7 +108,7 @@
             if (imp1) {
                 carrier = imp1(networkInfo, subscriberCellularProvider);
             }
-            NSString* (*imp2)(id, SEL) = (NSString* (*)(id, SEL))[carrier methodForSelector:carrierName];
+            NSString *(*imp2)(id, SEL) = (NSString *(*)(id, SEL))[carrier methodForSelector:carrierName];
             if (imp2) {
                 _carrier = imp2(carrier, carrierName);
             }
@@ -121,7 +121,7 @@
     return _carrier;
 }
 
-- (NSString*)country {
+- (NSString *)country {
     if (!_country) {
         _country = [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey: NSLocaleCountryCode
                                                                                value: [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]];
@@ -129,7 +129,7 @@
     return _country;
 }
 
-- (NSString*)language {
+- (NSString *)language {
     if (!_language) {
         _language = [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey: NSLocaleLanguageCode
                                                                                 value: [[NSLocale preferredLanguages] objectAtIndex:0]];
@@ -137,7 +137,7 @@
     return _language;
 }
 
-- (NSString*)vendorID {
+- (NSString *)vendorID {
     if (!_vendorID) {
 #if !TARGET_OS_OSX
         if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0) {
@@ -154,7 +154,7 @@
     return _vendorID;
 }
 
-+ (NSString*)getVendorID:(int) maxAttempts {
++ (NSString *)getVendorID:(int) maxAttempts {
 #if !TARGET_OS_OSX
     NSString *identifier = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
 #else
@@ -169,13 +169,13 @@
     }
 }
 
-+ (NSString*)generateUUID {
++ (NSString *)generateUUID {
     // Add "R" at the end of the ID to distinguish it from advertiserId
     NSString *result = [[AMPUtils generateUUID] stringByAppendingString:@"R"];
     return result;
 }
 
-+ (NSString*)getPlatformString {
++ (NSString *)getPlatformString {
 #if !TARGET_OS_OSX
     const char *sysctl_name = "hw.machine";
 #else
@@ -190,7 +190,7 @@
     return platform;
 }
 
-+ (NSString*)getDeviceModel {
++ (NSString *)getDeviceModel {
     NSString *platform = [self getPlatformString];
     // == iPhone ==
     // iPhone 1

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -123,16 +123,16 @@
 
 - (NSString *)country {
     if (!_country) {
-        _country = [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey: NSLocaleCountryCode
-                                                                               value: [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]];
+        _country = [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey:NSLocaleCountryCode
+                                                                               value:[[NSLocale currentLocale] objectForKey:NSLocaleCountryCode]];
     }
     return _country;
 }
 
 - (NSString *)language {
     if (!_language) {
-        _language = [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey: NSLocaleLanguageCode
-                                                                                value: [[NSLocale preferredLanguages] objectAtIndex:0]];
+        _language = [[NSLocale localeWithLocaleIdentifier:@"en_US"] displayNameForKey:NSLocaleLanguageCode
+                                                                                value:[[NSLocale preferredLanguages] objectAtIndex:0]];
     }
     return _language;
 }

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -44,7 +44,7 @@
 #endif
 #endif
 
-@interface AMPDeviceInfo()
+@interface AMPDeviceInfo ()
 @end
 
 @implementation AMPDeviceInfo {

--- a/Sources/Amplitude/AMPEventExplorer.m
+++ b/Sources/Amplitude/AMPEventExplorer.m
@@ -82,7 +82,7 @@
     });
 }
 
-- (void)bubbleViewDragged:(UIPanGestureRecognizer*)sender {
+- (void)bubbleViewDragged:(UIPanGestureRecognizer *)sender {
     CGPoint translation = [sender translationInView:self.bubbleView];
     
     CGFloat statusBarHeight = [AMPUtils statusBarHeight];

--- a/Sources/Amplitude/AMPEventExplorer.m
+++ b/Sources/Amplitude/AMPEventExplorer.m
@@ -52,10 +52,10 @@
         CGFloat screenHeight = screenRect.size.height;
         NSInteger bottomOffset = [AMPUtils barBottomOffset];
             
-        self.bubbleView = [[AMPBubbleView alloc] initWithFrame: CGRectMake(screenWidth - 50,
-                                                                           screenHeight - 50 - bottomOffset,
-                                                                           35,
-                                                                           35)];
+        self.bubbleView = [[AMPBubbleView alloc] initWithFrame:CGRectMake(screenWidth - 50,
+                                                                          screenHeight - 50 - bottomOffset,
+                                                                          35,
+                                                                          35)];
         
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC));
         dispatch_after(popTime, dispatch_get_main_queue(), ^{

--- a/Sources/Amplitude/AMPIdentify.h
+++ b/Sources/Amplitude/AMPIdentify.h
@@ -72,7 +72,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify *)add:(NSString *) property value:(NSObject *) value;
+- (AMPIdentify *)add:(NSString *)property value:(NSObject *)value;
 
 /**
  Append a value or values to a user property.
@@ -87,7 +87,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify *)append:(NSString *) property value:(NSObject *) value;
+- (AMPIdentify *)append:(NSString *)property value:(NSObject *)value;
 
 /*
  Internal method for clearing user properties.
@@ -109,7 +109,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify *)prepend:(NSString *) property value:(NSObject *) value;
+- (AMPIdentify *)prepend:(NSString *)property value:(NSObject *)value;
 
 /**
  Sets the value of a given user property. If the value already exists, it will be overwritten with the new value.
@@ -122,7 +122,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify *)set:(NSString *) property value:(NSObject *) value;
+- (AMPIdentify *)set:(NSString *)property value:(NSObject *)value;
 
 
 /**
@@ -138,7 +138,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify *)setOnce:(NSString *) property value:(NSObject *) value;
+- (AMPIdentify *)setOnce:(NSString *)property value:(NSObject *)value;
 
 
 /**
@@ -150,6 +150,6 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify *)unset:(NSString *) property;
+- (AMPIdentify *)unset:(NSString *)property;
 
 @end

--- a/Sources/Amplitude/AMPIdentify.h
+++ b/Sources/Amplitude/AMPIdentify.h
@@ -72,7 +72,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify*)add:(NSString*) property value:(NSObject*) value;
+- (AMPIdentify *)add:(NSString *) property value:(NSObject *) value;
 
 /**
  Append a value or values to a user property.
@@ -87,14 +87,14 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify*)append:(NSString*) property value:(NSObject*) value;
+- (AMPIdentify *)append:(NSString *) property value:(NSObject *) value;
 
 /*
  Internal method for clearing user properties.
 
  **Note:** $clearAll needs to be sent on its own Identify object. If there are already other operations, then don't add $clearAll. If $clearAll already in an Identify object, don't allow other operations to be added.
  */
-- (AMPIdentify*)clearAll;
+- (AMPIdentify *)clearAll;
 
 /**
  Prepend a value or values to a user property. Prepend means inserting the value or values at the front of a list.
@@ -109,7 +109,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify*)prepend:(NSString*) property value:(NSObject*) value;
+- (AMPIdentify *)prepend:(NSString *) property value:(NSObject *) value;
 
 /**
  Sets the value of a given user property. If the value already exists, it will be overwritten with the new value.
@@ -122,7 +122,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify*)set:(NSString*) property value:(NSObject*) value;
+- (AMPIdentify *)set:(NSString *) property value:(NSObject *) value;
 
 
 /**
@@ -138,7 +138,7 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify*)setOnce:(NSString*) property value:(NSObject*) value;
+- (AMPIdentify *)setOnce:(NSString *) property value:(NSObject *) value;
 
 
 /**
@@ -150,6 +150,6 @@
 
  @see [User Properties and User Property Operations](https://github.com/amplitude/amplitude-ios#user-properties-and-user-property-operations)
  */
-- (AMPIdentify*)unset:(NSString*) property;
+- (AMPIdentify *)unset:(NSString *) property;
 
 @end

--- a/Sources/Amplitude/AMPIdentify.m
+++ b/Sources/Amplitude/AMPIdentify.m
@@ -56,7 +56,7 @@
     return [[self alloc] init];
 }
 
-- (AMPIdentify *)add:(NSString *) property value:(NSObject *) value {
+- (AMPIdentify *)add:(NSString *)property value:(NSObject *)value {
     if ([value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSString class]]) {
         [self addToUserProperties:AMP_OP_ADD property:property value:value];
     } else {
@@ -65,7 +65,7 @@
     return self;
 }
 
-- (AMPIdentify *)append:(NSString *) property value:(NSObject *) value {
+- (AMPIdentify *)append:(NSString *)property value:(NSObject *)value {
     [self addToUserProperties:AMP_OP_APPEND property:property value:value];
     return self;
 }
@@ -81,27 +81,27 @@
     return self;
 }
 
-- (AMPIdentify *)prepend:(NSString *) property value:(NSObject *) value {
+- (AMPIdentify *)prepend:(NSString *)property value:(NSObject *)value {
     [self addToUserProperties:AMP_OP_PREPEND property:property value:value];
     return self;
 }
 
-- (AMPIdentify *)set:(NSString *) property value:(NSObject *) value {
+- (AMPIdentify *)set:(NSString *)property value:(NSObject *)value {
     [self addToUserProperties:AMP_OP_SET property:property value:value];
     return self;
 }
 
-- (AMPIdentify *)setOnce:(NSString *) property value:(NSObject *) value {
+- (AMPIdentify *)setOnce:(NSString *)property value:(NSObject *)value {
     [self addToUserProperties:AMP_OP_SET_ONCE property:property value:value];
     return self;
 }
 
-- (AMPIdentify *)unset:(NSString *) property {
+- (AMPIdentify *)unset:(NSString *)property {
     [self addToUserProperties:AMP_OP_UNSET property:property value:@"-"];
     return self;
 }
 
-- (void)addToUserProperties:(NSString *)operation property:(NSString *) property value:(NSObject *) value {
+- (void)addToUserProperties:(NSString *)operation property:(NSString *)property value:(NSObject *)value {
     if (value == nil) {
         AMPLITUDE_LOG(@"Attempting to perform operation '%@' with nil value for property '%@', ignoring", operation, property);
         return;

--- a/Sources/Amplitude/AMPIdentify.m
+++ b/Sources/Amplitude/AMPIdentify.m
@@ -56,7 +56,7 @@
     return [[self alloc] init];
 }
 
-- (AMPIdentify*)add:(NSString*) property value:(NSObject*) value {
+- (AMPIdentify *)add:(NSString *) property value:(NSObject *) value {
     if ([value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSString class]]) {
         [self addToUserProperties:AMP_OP_ADD property:property value:value];
     } else {
@@ -65,12 +65,12 @@
     return self;
 }
 
-- (AMPIdentify*)append:(NSString*) property value:(NSObject*) value {
+- (AMPIdentify *)append:(NSString *) property value:(NSObject *) value {
     [self addToUserProperties:AMP_OP_APPEND property:property value:value];
     return self;
 }
 
-- (AMPIdentify*)clearAll {
+- (AMPIdentify *)clearAll {
     if ([_userPropertyOperations count] > 0) {
         if ([_userPropertyOperations objectForKey:AMP_OP_CLEAR_ALL] == nil) {
             AMPLITUDE_LOG(@"Need to send $clearAll on its own Identify object without any other operations, skipping $clearAll");
@@ -81,27 +81,27 @@
     return self;
 }
 
-- (AMPIdentify*)prepend:(NSString*) property value:(NSObject*) value {
+- (AMPIdentify *)prepend:(NSString *) property value:(NSObject *) value {
     [self addToUserProperties:AMP_OP_PREPEND property:property value:value];
     return self;
 }
 
-- (AMPIdentify*)set:(NSString*) property value:(NSObject*) value {
+- (AMPIdentify *)set:(NSString *) property value:(NSObject *) value {
     [self addToUserProperties:AMP_OP_SET property:property value:value];
     return self;
 }
 
-- (AMPIdentify*)setOnce:(NSString*) property value:(NSObject*) value {
+- (AMPIdentify *)setOnce:(NSString *) property value:(NSObject *) value {
     [self addToUserProperties:AMP_OP_SET_ONCE property:property value:value];
     return self;
 }
 
-- (AMPIdentify*)unset:(NSString*) property {
+- (AMPIdentify *)unset:(NSString *) property {
     [self addToUserProperties:AMP_OP_UNSET property:property value:@"-"];
     return self;
 }
 
-- (void)addToUserProperties:(NSString*)operation property:(NSString*) property value:(NSObject*) value {
+- (void)addToUserProperties:(NSString *)operation property:(NSString *) property value:(NSObject *) value {
     if (value == nil) {
         AMPLITUDE_LOG(@"Attempting to perform operation '%@' with nil value for property '%@', ignoring", operation, property);
         return;

--- a/Sources/Amplitude/AMPIdentify.m
+++ b/Sources/Amplitude/AMPIdentify.m
@@ -37,7 +37,7 @@
 #import "AMPConstants.h"
 #import "AMPUtils.h"
 
-@interface AMPIdentify()
+@interface AMPIdentify ()
 @end
 
 @implementation AMPIdentify {

--- a/Sources/Amplitude/AMPRevenue.h
+++ b/Sources/Amplitude/AMPRevenue.h
@@ -131,7 +131,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue *)setQuantity:(NSInteger) quantity;
+- (AMPRevenue *)setQuantity:(NSInteger)quantity;
 
 
 /**

--- a/Sources/Amplitude/AMPRevenue.h
+++ b/Sources/Amplitude/AMPRevenue.h
@@ -120,7 +120,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue*)setProductIdentifier:(NSString*) productIdentifier;
+- (AMPRevenue *)setProductIdentifier:(NSString *) productIdentifier;
 
 /**
  Set a value for the quantity.
@@ -131,7 +131,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue*)setQuantity:(NSInteger) quantity;
+- (AMPRevenue *)setQuantity:(NSInteger) quantity;
 
 
 /**
@@ -143,7 +143,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue*)setPrice:(NSNumber*) price;
+- (AMPRevenue *)setPrice:(NSNumber *) price;
 
 
 /**
@@ -153,7 +153,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue*)setRevenueType:(NSString*) revenueType;
+- (AMPRevenue *)setRevenueType:(NSString *) revenueType;
 
 
 /**
@@ -166,7 +166,7 @@
  @see [Revenue Validation](https://github.com/amplitude/amplitude-ios#revenue-verification)
  @see [Validating Receipts with the App Store](https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW1)
  */
-- (AMPRevenue*)setReceipt:(NSData*) receipt;
+- (AMPRevenue *)setReceipt:(NSData *) receipt;
 
 /**
  Set event properties for the revenue event.
@@ -177,9 +177,9 @@
 
  @see [Setting Event Properties](https://github.com/amplitude/amplitude-ios#setting-event-properties)
  */
-- (AMPRevenue*)setEventProperties:(NSDictionary*) eventProperties;
+- (AMPRevenue *)setEventProperties:(NSDictionary *) eventProperties;
 
 
-- (NSDictionary*)toNSDictionary;
+- (NSDictionary *)toNSDictionary;
 
 @end

--- a/Sources/Amplitude/AMPRevenue.h
+++ b/Sources/Amplitude/AMPRevenue.h
@@ -120,7 +120,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue *)setProductIdentifier:(NSString *) productIdentifier;
+- (AMPRevenue *)setProductIdentifier:(NSString *)productIdentifier;
 
 /**
  Set a value for the quantity.
@@ -143,7 +143,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue *)setPrice:(NSNumber *) price;
+- (AMPRevenue *)setPrice:(NSNumber *)price;
 
 
 /**
@@ -153,7 +153,7 @@
 
  @returns the same [AMPRevenue](#) object, allowing you to chain multiple method calls together.
  */
-- (AMPRevenue *)setRevenueType:(NSString *) revenueType;
+- (AMPRevenue *)setRevenueType:(NSString *)revenueType;
 
 
 /**
@@ -166,7 +166,7 @@
  @see [Revenue Validation](https://github.com/amplitude/amplitude-ios#revenue-verification)
  @see [Validating Receipts with the App Store](https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW1)
  */
-- (AMPRevenue *)setReceipt:(NSData *) receipt;
+- (AMPRevenue *)setReceipt:(NSData *)receipt;
 
 /**
  Set event properties for the revenue event.
@@ -177,7 +177,7 @@
 
  @see [Setting Event Properties](https://github.com/amplitude/amplitude-ios#setting-event-properties)
  */
-- (AMPRevenue *)setEventProperties:(NSDictionary *) eventProperties;
+- (AMPRevenue *)setEventProperties:(NSDictionary *)eventProperties;
 
 
 - (NSDictionary *)toNSDictionary;

--- a/Sources/Amplitude/AMPRevenue.m
+++ b/Sources/Amplitude/AMPRevenue.m
@@ -65,7 +65,7 @@
     return YES;
 }
 
-- (AMPRevenue *)setProductIdentifier:(NSString *) productIdentifier {
+- (AMPRevenue *)setProductIdentifier:(NSString *)productIdentifier {
     if ([AMPUtils isEmptyString:productIdentifier]) {
         AMPLITUDE_LOG(@"Invalid empty productIdentifier");
         return self;

--- a/Sources/Amplitude/AMPRevenue.m
+++ b/Sources/Amplitude/AMPRevenue.m
@@ -65,7 +65,7 @@
     return YES;
 }
 
-- (AMPRevenue*)setProductIdentifier:(NSString *) productIdentifier {
+- (AMPRevenue *)setProductIdentifier:(NSString *) productIdentifier {
     if ([AMPUtils isEmptyString:productIdentifier]) {
         AMPLITUDE_LOG(@"Invalid empty productIdentifier");
         return self;
@@ -75,33 +75,33 @@
     return self;
 }
 
-- (AMPRevenue*)setQuantity:(NSInteger)quantity {
+- (AMPRevenue *)setQuantity:(NSInteger)quantity {
     _quantity = quantity;
     return self;
 }
 
-- (AMPRevenue*)setPrice:(NSNumber *)price {
+- (AMPRevenue *)setPrice:(NSNumber *)price {
     _price = price;
     return self;
 }
 
-- (AMPRevenue*)setRevenueType:(NSString*)revenueType {
+- (AMPRevenue *)setRevenueType:(NSString *)revenueType {
     _revenueType = revenueType;
     return self;
 }
 
-- (AMPRevenue*)setReceipt:(NSData*)receipt {
+- (AMPRevenue *)setReceipt:(NSData *)receipt {
     _receipt = receipt;
     return self;
 }
 
-- (AMPRevenue*)setEventProperties:(NSDictionary*)eventProperties {
+- (AMPRevenue *)setEventProperties:(NSDictionary *)eventProperties {
     eventProperties = [eventProperties copy];
     _properties = eventProperties;
     return self;
 }
 
-- (NSDictionary*)toNSDictionary {
+- (NSDictionary *)toNSDictionary {
     NSMutableDictionary *dict;
     if (_properties == nil) {
         dict = [[NSMutableDictionary alloc] init];

--- a/Sources/Amplitude/AMPRevenue.m
+++ b/Sources/Amplitude/AMPRevenue.m
@@ -37,11 +37,11 @@
 #import "AMPConstants.h"
 #import "AMPUtils.h"
 
-@interface AMPRevenue()
+@interface AMPRevenue ()
 
 @end
 
-@implementation AMPRevenue{}
+@implementation AMPRevenue
 
 - (instancetype)init {
     if ((self = [super init])) {

--- a/Sources/Amplitude/AMPTrackingOptions.h
+++ b/Sources/Amplitude/AMPTrackingOptions.h
@@ -27,22 +27,22 @@
 
 @property (nonatomic, strong, readonly) NSMutableSet *disabledFields;
 
-- (AMPTrackingOptions*)disableCarrier;
-- (AMPTrackingOptions*)disableCity;
-- (AMPTrackingOptions*)disableCountry;
-- (AMPTrackingOptions*)disableDeviceManufacturer;
-- (AMPTrackingOptions*)disableDeviceModel;
-- (AMPTrackingOptions*)disableDMA;
-- (AMPTrackingOptions*)disableIDFA;
-- (AMPTrackingOptions*)disableIDFV;
-- (AMPTrackingOptions*)disableIPAddress;
-- (AMPTrackingOptions*)disableLanguage;
-- (AMPTrackingOptions*)disableLatLng;
-- (AMPTrackingOptions*)disableOSName;
-- (AMPTrackingOptions*)disableOSVersion;
-- (AMPTrackingOptions*)disablePlatform;
-- (AMPTrackingOptions*)disableRegion;
-- (AMPTrackingOptions*)disableVersionName;
+- (AMPTrackingOptions *)disableCarrier;
+- (AMPTrackingOptions *)disableCity;
+- (AMPTrackingOptions *)disableCountry;
+- (AMPTrackingOptions *)disableDeviceManufacturer;
+- (AMPTrackingOptions *)disableDeviceModel;
+- (AMPTrackingOptions *)disableDMA;
+- (AMPTrackingOptions *)disableIDFA;
+- (AMPTrackingOptions *)disableIDFV;
+- (AMPTrackingOptions *)disableIPAddress;
+- (AMPTrackingOptions *)disableLanguage;
+- (AMPTrackingOptions *)disableLatLng;
+- (AMPTrackingOptions *)disableOSName;
+- (AMPTrackingOptions *)disableOSVersion;
+- (AMPTrackingOptions *)disablePlatform;
+- (AMPTrackingOptions *)disableRegion;
+- (AMPTrackingOptions *)disableVersionName;
 
 - (BOOL)shouldTrackCarrier;
 - (BOOL)shouldTrackCity;

--- a/Sources/Amplitude/AMPTrackingOptions.h
+++ b/Sources/Amplitude/AMPTrackingOptions.h
@@ -62,9 +62,9 @@
 - (BOOL)shouldTrackVersionName;
 
 - (NSMutableDictionary *)getApiPropertiesTrackingOption;
-- (AMPTrackingOptions *)mergeIn: (AMPTrackingOptions *)options;
+- (AMPTrackingOptions *)mergeIn:(AMPTrackingOptions *)options;
 + (instancetype)options;
 + (AMPTrackingOptions *)forCoppaControl;
-+ (AMPTrackingOptions *)copyOf: (AMPTrackingOptions *)origin;
++ (AMPTrackingOptions *)copyOf:(AMPTrackingOptions *)origin;
 
 @end

--- a/Sources/Amplitude/AMPTrackingOptions.m
+++ b/Sources/Amplitude/AMPTrackingOptions.m
@@ -209,7 +209,7 @@
     return ![self.disabledFields containsObject:field];
 }
 
-- (NSMutableDictionary *) getApiPropertiesTrackingOption {
+- (NSMutableDictionary *)getApiPropertiesTrackingOption {
     NSMutableDictionary *apiPropertiesTrackingOptions = [[NSMutableDictionary alloc] init];
     if (self.disabledFields.count == 0) {
         return apiPropertiesTrackingOptions;

--- a/Sources/Amplitude/AMPTrackingOptions.m
+++ b/Sources/Amplitude/AMPTrackingOptions.m
@@ -231,7 +231,7 @@
     return apiPropertiesTrackingOptions;
 }
 
-- (AMPTrackingOptions *)mergeIn: (AMPTrackingOptions *)other {
+- (AMPTrackingOptions *)mergeIn:(AMPTrackingOptions *)other {
     for (NSString *field in other.disabledFields) {
         [self disableTrackingField:field];
     }
@@ -253,7 +253,7 @@
     return options;
 }
 
-+ (AMPTrackingOptions *)copyOf: (AMPTrackingOptions *)origin {
++ (AMPTrackingOptions *)copyOf:(AMPTrackingOptions *)origin {
     AMPTrackingOptions *options = [[AMPTrackingOptions alloc] init];
     for (NSString *field in origin.disabledFields) {
         [options disableTrackingField:field];

--- a/Sources/Amplitude/AMPTrackingOptions.m
+++ b/Sources/Amplitude/AMPTrackingOptions.m
@@ -55,7 +55,7 @@
     return [[self alloc] init];
 }
 
-- (AMPTrackingOptions*)disableCarrier {
+- (AMPTrackingOptions *)disableCarrier {
     [self disableTrackingField:AMP_TRACKING_OPTION_CARRIER];
     return self;
 }
@@ -64,7 +64,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_CARRIER];
 }
 
-- (AMPTrackingOptions*)disableCity {
+- (AMPTrackingOptions *)disableCity {
     [self disableTrackingField:AMP_TRACKING_OPTION_CITY];
     return self;
 }
@@ -73,7 +73,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_CITY];
 }
 
-- (AMPTrackingOptions*)disableCountry {
+- (AMPTrackingOptions *)disableCountry {
     [self disableTrackingField:AMP_TRACKING_OPTION_COUNTRY];
     return self;
 }
@@ -82,7 +82,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_COUNTRY];
 }
 
-- (AMPTrackingOptions*)disableDeviceManufacturer {
+- (AMPTrackingOptions *)disableDeviceManufacturer {
     [self disableTrackingField:AMP_TRACKING_OPTION_DEVICE_MANUFACTURER];
     return self;
 }
@@ -91,7 +91,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_DEVICE_MANUFACTURER];
 }
 
-- (AMPTrackingOptions*)disableDeviceModel {
+- (AMPTrackingOptions *)disableDeviceModel {
     [self disableTrackingField:AMP_TRACKING_OPTION_DEVICE_MODEL];
     return self;
 }
@@ -100,7 +100,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_DEVICE_MODEL];
 }
 
-- (AMPTrackingOptions*)disableDMA {
+- (AMPTrackingOptions *)disableDMA {
     [self disableTrackingField:AMP_TRACKING_OPTION_DMA];
     return self;
 }
@@ -109,7 +109,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_DMA];
 }
 
-- (AMPTrackingOptions*)disableIDFA {
+- (AMPTrackingOptions *)disableIDFA {
     [self disableTrackingField:AMP_TRACKING_OPTION_IDFA];
     return self;
 }
@@ -118,7 +118,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_IDFA];
 }
 
-- (AMPTrackingOptions*)disableIDFV
+- (AMPTrackingOptions *)disableIDFV
 {
     [self disableTrackingField:AMP_TRACKING_OPTION_IDFV];
     return self;
@@ -128,7 +128,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_IDFV];
 }
 
-- (AMPTrackingOptions*)disableIPAddress {
+- (AMPTrackingOptions *)disableIPAddress {
     [self disableTrackingField:AMP_TRACKING_OPTION_IP_ADDRESS];
     return self;
 }
@@ -137,7 +137,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_IP_ADDRESS];
 }
 
-- (AMPTrackingOptions*)disableLanguage
+- (AMPTrackingOptions *)disableLanguage
 {
     [self disableTrackingField:AMP_TRACKING_OPTION_LANGUAGE];
     return self;
@@ -147,7 +147,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_LANGUAGE];
 }
 
-- (AMPTrackingOptions*)disableLatLng {
+- (AMPTrackingOptions *)disableLatLng {
     [self disableTrackingField:AMP_TRACKING_OPTION_LAT_LNG];
     return self;
 }
@@ -156,7 +156,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_LAT_LNG];
 }
 
-- (AMPTrackingOptions*)disableOSName {
+- (AMPTrackingOptions *)disableOSName {
     [self disableTrackingField:AMP_TRACKING_OPTION_OS_NAME];
     return self;
 }
@@ -165,7 +165,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_OS_NAME];
 }
 
-- (AMPTrackingOptions*)disableOSVersion {
+- (AMPTrackingOptions *)disableOSVersion {
     [self disableTrackingField:AMP_TRACKING_OPTION_OS_VERSION];
     return self;
 }
@@ -174,7 +174,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_OS_VERSION];
 }
 
-- (AMPTrackingOptions*)disablePlatform {
+- (AMPTrackingOptions *)disablePlatform {
     [self disableTrackingField:AMP_TRACKING_OPTION_PLATFORM];
     return self;
 }
@@ -183,7 +183,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_PLATFORM];
 }
 
-- (AMPTrackingOptions*)disableRegion {
+- (AMPTrackingOptions *)disableRegion {
     [self disableTrackingField:AMP_TRACKING_OPTION_REGION];
     return self;
 }
@@ -192,7 +192,7 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_REGION];
 }
 
-- (AMPTrackingOptions*)disableVersionName {
+- (AMPTrackingOptions *)disableVersionName {
     [self disableTrackingField:AMP_TRACKING_OPTION_VERSION_NAME];
     return self;
 }
@@ -201,15 +201,15 @@
     return [self shouldTrackField:AMP_TRACKING_OPTION_VERSION_NAME];
 }
 
-- (void) disableTrackingField:(NSString*)field {
+- (void) disableTrackingField:(NSString *)field {
     [self.disabledFields addObject:field];
 }
 
-- (BOOL) shouldTrackField:(NSString*)field {
+- (BOOL) shouldTrackField:(NSString *)field {
     return ![self.disabledFields containsObject:field];
 }
 
-- (NSMutableDictionary*) getApiPropertiesTrackingOption {
+- (NSMutableDictionary *) getApiPropertiesTrackingOption {
     NSMutableDictionary *apiPropertiesTrackingOptions = [[NSMutableDictionary alloc] init];
     if (self.disabledFields.count == 0) {
         return apiPropertiesTrackingOptions;

--- a/Sources/Amplitude/AMPTrackingOptions.m
+++ b/Sources/Amplitude/AMPTrackingOptions.m
@@ -36,7 +36,7 @@
 #import "AMPTrackingOptions.h"
 #import "AMPConstants.h"
 
-@interface AMPTrackingOptions()
+@interface AMPTrackingOptions ()
 
 @property (nonatomic, strong, readwrite) NSMutableSet *disabledFields;
 

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -30,8 +30,8 @@
 
 + (NSString *)generateUUID;
 + (id)makeJSONSerializable:(id) obj;
-+ (BOOL)isEmptyString:(NSString *) str;
-+ (NSDictionary *)validateGroups:(NSDictionary *) obj;
++ (BOOL)isEmptyString:(NSString *)str;
++ (NSDictionary *)validateGroups:(NSDictionary *)obj;
 + (NSString *)platformDataDirectory;
 
 #if !TARGET_OS_OSX

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -29,7 +29,7 @@
 @interface AMPUtils : NSObject
 
 + (NSString *)generateUUID;
-+ (id)makeJSONSerializable:(id) obj;
++ (id)makeJSONSerializable:(id)obj;
 + (BOOL)isEmptyString:(NSString *)str;
 + (NSDictionary *)validateGroups:(NSDictionary *)obj;
 + (NSString *)platformDataDirectory;

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -28,11 +28,11 @@
 
 @interface AMPUtils : NSObject
 
-+ (NSString*)generateUUID;
++ (NSString *)generateUUID;
 + (id)makeJSONSerializable:(id) obj;
-+ (BOOL)isEmptyString:(NSString*) str;
-+ (NSDictionary*)validateGroups:(NSDictionary*) obj;
-+ (NSString*)platformDataDirectory;
++ (BOOL)isEmptyString:(NSString *) str;
++ (NSDictionary *)validateGroups:(NSDictionary *) obj;
++ (NSString *)platformDataDirectory;
 
 #if !TARGET_OS_OSX
 + (UIApplication *)getSharedApplication;

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -50,7 +50,7 @@
 #if __has_feature(objc_arc)
     NSString *uuidStr = (__bridge_transfer NSString *)CFUUIDCreateString(kCFAllocatorDefault, uuid);
 #else
-    NSString *uuidStr = (NSString *) CFUUIDCreateString(kCFAllocatorDefault, uuid);
+    NSString *uuidStr = (NSString *)CFUUIDCreateString(kCFAllocatorDefault, uuid);
 #endif
     CFRelease(uuid);
     return uuidStr;
@@ -100,7 +100,7 @@
     return str == nil || [str isKindOfClass:[NSNull class]] || [str length] == 0;
 }
 
-+ (NSString *)coerceToString: (id) obj withName:(NSString *) name
++ (NSString *)coerceToString: (id) obj withName:(NSString *)name
 {
     NSString *coercedString;
     if (![obj isKindOfClass:[NSString class]]) {
@@ -146,7 +146,7 @@
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
-+ (NSString *) platformDataDirectory {
++ (NSString *)platformDataDirectory {
 #if TARGET_OS_TV
     return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #else

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -148,9 +148,9 @@
 
 + (NSString *)platformDataDirectory {
 #if TARGET_OS_TV
-    return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
+    return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0];
 #else
-    return [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
+    return [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
 #endif
 }
 

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -100,7 +100,7 @@
     return str == nil || [str isKindOfClass:[NSNull class]] || [str length] == 0;
 }
 
-+ (NSString *)coerceToString: (id)obj withName:(NSString *)name
++ (NSString *)coerceToString:(id)obj withName:(NSString *)name
 {
     NSString *coercedString;
     if (![obj isKindOfClass:[NSString class]]) {

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -45,7 +45,7 @@
     return nil;
 }
 
-+ (NSString*)generateUUID {
++ (NSString *)generateUUID {
     CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
 #if __has_feature(objc_arc)
     NSString *uuidStr = (__bridge_transfer NSString *)CFUUIDCreateString(kCFAllocatorDefault, uuid);
@@ -96,7 +96,7 @@
     return str;
 }
 
-+ (BOOL)isEmptyString:(NSString*)str {
++ (BOOL)isEmptyString:(NSString *)str {
     return str == nil || [str isKindOfClass:[NSNull class]] || [str length] == 0;
 }
 
@@ -146,7 +146,7 @@
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
-+ (NSString*) platformDataDirectory {
++ (NSString *) platformDataDirectory {
 #if TARGET_OS_TV
     return [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
 #else

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -137,7 +137,7 @@
                 }
             }
             dict[coercedKey] = [NSArray arrayWithArray:arr];
-        } else if ([value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSDate class]]){
+        } else if ([value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSDate class]]) {
             dict[coercedKey] = [self coerceToString:value withName:@"groupName"];
         } else {
             AMPLITUDE_LOG(@"WARNING: Invalid groupName value for groupType %@ (received class %@). Please use NSString or NSArray of NSStrings", coercedKey, [value class]);

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -100,7 +100,7 @@
     return str == nil || [str isKindOfClass:[NSNull class]] || [str length] == 0;
 }
 
-+ (NSString *)coerceToString: (id) obj withName:(NSString *)name
++ (NSString *)coerceToString: (id)obj withName:(NSString *)name
 {
     NSString *coercedString;
     if (![obj isKindOfClass:[NSString class]]) {

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -35,7 +35,7 @@
 
 #import "AMPUtils.h"
 
-@interface AMPUtils()
+@interface AMPUtils ()
 @end
 
 @implementation AMPUtils

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -594,7 +594,7 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
  */
 - (void)useAdvertisingIdForDeviceId;
 
-- (void)setTrackingOptions:(AMPTrackingOptions*)options;
+- (void)setTrackingOptions:(AMPTrackingOptions *)options;
 
 /**
  Enable COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, city, IP address and location tracking.
@@ -628,7 +628,7 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 
  @returns the deviceId.
  */
-- (NSString*)getDeviceId;
+- (NSString *)getDeviceId;
 
 /**
  Regenerates a new random deviceId for current user. Note: this is not recommended unless you know what you are doing. This can be used in conjunction with setUserId:nil to anonymize users after they log out. With a nil userId and a completely new deviceId, the current user would appear as a brand new user in dashboard.

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -134,8 +134,8 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     BOOL _inForeground;
     BOOL _offline;
 
-    NSString* _serverUrl;
-    NSString* _token;
+    NSString *_serverUrl;
+    NSString *_token;
 }
 
 #pragma clang diagnostic push
@@ -444,7 +444,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
                         // The earliest time to fetch dynamic config
                         [self refreshDynamicConfig];
                         
-                        NSNumber* now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
+                        NSNumber *now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
                         [self startOrContinueSessionNSNumber:now];
                         self->_inForeground = YES;
         #if !TARGET_OS_OSX
@@ -664,12 +664,12 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     NSMutableDictionary *apiProperties = [event valueForKey:@"api_properties"];
 
     if ([_appliedTrackingOptions shouldTrackIDFA]) {
-        NSString* advertiserID = [self getAdSupportID];
+        NSString *advertiserID = [self getAdSupportID];
         if (advertiserID != nil) {
             [apiProperties setValue:advertiserID forKey:@"ios_idfa"];
         }
     }
-    NSString* vendorID = _deviceInfo.vendorID;
+    NSString *vendorID = _deviceInfo.vendorID;
     if ([_appliedTrackingOptions shouldTrackIDFV] && vendorID) {
         [apiProperties setValue:vendorID forKey:@"ios_idfv"];
     }
@@ -1039,7 +1039,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 #endif
 
-    NSNumber* now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
+    NSNumber *now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
 
 #if !TARGET_OS_OSX
     // Stop uploading
@@ -1063,7 +1063,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 #endif
 
-    NSNumber* now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
+    NSNumber *now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
 
 #if !TARGET_OS_OSX
     // Stop uploading
@@ -1164,7 +1164,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     NSMutableDictionary *apiProperties = [NSMutableDictionary dictionary];
     [apiProperties setValue:sessionEvent forKey:@"special"];
-    NSNumber* timestamp = [self lastEventTime];
+    NSNumber *timestamp = [self lastEventTime];
     [self logEvent:sessionEvent withEventProperties:nil withApiProperties:apiProperties withUserProperties:nil withGroups:nil withGroupProperties:nil withTimestamp:timestamp outOfSession:NO];
 }
 
@@ -1203,7 +1203,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (long long)previousSessionId {
-    NSNumber* previousSessionId = [self.dbHelper getLongValue:PREVIOUS_SESSION_ID];
+    NSNumber *previousSessionId = [self.dbHelper getLongValue:PREVIOUS_SESSION_ID];
     if (previousSessionId == nil) {
         return -1;
     }
@@ -1345,7 +1345,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         [self.dbHelper insertOrReplaceKeyValue:USER_ID value:self.userId];
 
         if (startNewSession) {
-            NSNumber* timestamp = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
+            NSNumber *timestamp = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
             [self setSessionId:[timestamp longLongValue]];
             [self refreshSessionTime:timestamp];
             if (self->_trackingSessionEvents) {
@@ -1532,7 +1532,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (NSString *)md5HexDigest:(NSString *)input {
-    const char* str = [input UTF8String];
+    const char *str = [input UTF8String];
     unsigned char result[CC_MD5_DIGEST_LENGTH];
     
 #pragma clang diagnostic push

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -501,35 +501,35 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 #pragma mark - logEvent
 
-- (void)logEvent:(NSString *) eventType {
+- (void)logEvent:(NSString *)eventType {
     [self logEvent:eventType withEventProperties:nil];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:nil];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties outOfSession:(BOOL) outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties outOfSession:(BOOL) outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:nil outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withGroups:(NSDictionary *)groups {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:groups outOfSession:NO];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withGroups:(NSDictionary *)groups outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:nil outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups withLongLongTimestamp:(long long) timestamp outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withGroups:(NSDictionary *)groups withLongLongTimestamp:(long long) timestamp outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:[NSNumber numberWithLongLong:timestamp] outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups withTimestamp:(NSNumber *) timestamp outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withGroups:(NSDictionary *)groups withTimestamp:(NSNumber *)timestamp outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:timestamp outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withApiProperties:(NSDictionary *) apiProperties withUserProperties:(NSDictionary *) userProperties withGroups:(NSDictionary *) groups withGroupProperties:(NSDictionary *) groupProperties withTimestamp:(NSNumber *) timestamp outOfSession:(BOOL) outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withApiProperties:(NSDictionary *)apiProperties withUserProperties:(NSDictionary *)userProperties withGroups:(NSDictionary *)groups withGroupProperties:(NSDictionary *)groupProperties withTimestamp:(NSNumber *)timestamp outOfSession:(BOOL) outOfSession {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logEvent");
         return;
@@ -623,7 +623,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (void)annotateEvent:(NSMutableDictionary *) event {
+- (void)annotateEvent:(NSMutableDictionary *)event {
     [event setValue:self.userId forKey:@"user_id"];
     [event setValue:self.deviceId forKey:@"device_id"];
     if ([_appliedTrackingOptions shouldTrackPlatform]) {
@@ -690,17 +690,17 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 // amount is a double in units of dollars
 // ex. $3.99 would be passed as [NSNumber numberWithDouble:3.99]
-- (void)logRevenue:(NSNumber *) amount
+- (void)logRevenue:(NSNumber *)amount
 {
     [self logRevenue:nil quantity:1 price:amount];
 }
 
-- (void)logRevenue:(NSString *) productIdentifier quantity:(NSInteger) quantity price:(NSNumber *) price
+- (void)logRevenue:(NSString *)productIdentifier quantity:(NSInteger) quantity price:(NSNumber *)price
 {
     [self logRevenue:productIdentifier quantity:quantity price:price receipt:nil];
 }
 
-- (void)logRevenue:(NSString *) productIdentifier quantity:(NSInteger) quantity price:(NSNumber *) price receipt:(NSData *) receipt
+- (void)logRevenue:(NSString *)productIdentifier quantity:(NSInteger) quantity price:(NSNumber *)price receipt:(NSData *)receipt
 {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logRevenue:");
@@ -727,7 +727,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logEvent:kAMPRevenueEvent withEventProperties:nil withApiProperties:apiProperties withUserProperties:nil withGroups:nil withGroupProperties:nil withTimestamp:nil outOfSession:NO];
 }
 
-- (void)logRevenueV2:(AMPRevenue *) revenue {
+- (void)logRevenueV2:(AMPRevenue *)revenue {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logRevenueV2");
         return;
@@ -903,7 +903,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return results;
 }
 
-- (void)makeEventUploadPostRequest:(NSString *) url events:(NSString *) events numEvents:(long) numEvents maxEventId:(long long) maxEventId maxIdentifyId:(long long) maxIdentifyId {
+- (void)makeEventUploadPostRequest:(NSString *)url events:(NSString *)events numEvents:(long) numEvents maxEventId:(long long) maxEventId maxIdentifyId:(long long) maxIdentifyId {
     NSMutableURLRequest *request =[NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     [request setTimeoutInterval:60.0];
 
@@ -1104,7 +1104,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
  *
  * Returns YES if a new session was created.
  */
-- (BOOL)startOrContinueSessionNSNumber:(NSNumber *) timestamp {
+- (BOOL)startOrContinueSessionNSNumber:(NSNumber *)timestamp {
     if (!_inForeground) {
         if ([self inSession]) {
             if ([self isWithinMinTimeBetweenSessions:timestamp]) {
@@ -1172,7 +1172,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return _sessionId >= 0;
 }
 
-- (BOOL)isWithinMinTimeBetweenSessions:(NSNumber *) timestamp {
+- (BOOL)isWithinMinTimeBetweenSessions:(NSNumber *)timestamp {
     NSNumber *previousSessionTime = [self lastEventTime];
     long long timeDelta = [timestamp longLongValue] - [previousSessionTime longLongValue];
 
@@ -1190,7 +1190,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 /**
  * Update the session timer if there's a running session.
  */
-- (void)refreshSessionTime:(NSNumber *) timestamp {
+- (void)refreshSessionTime:(NSNumber *)timestamp {
     if (![self inSession]) {
         return;
     }
@@ -1249,7 +1249,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 #pragma mark - configurations
 
-- (void)setUserProperties:(NSDictionary *) userProperties {
+- (void)setUserProperties:(NSDictionary *)userProperties {
     if (userProperties == nil || ![self isArgument:userProperties validType:[NSDictionary class] methodName:@"setUserProperties:"] || [userProperties count] == 0) {
         return;
     }
@@ -1273,7 +1273,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 // maintain for legacy
 // replace argument is deprecated. In earlier versions of this SDK, this replaced the in-memory userProperties dictionary with the input, but now userProperties are no longer stored in memory.
-- (void)setUserProperties:(NSDictionary *) userProperties replace:(BOOL) replace {
+- (void)setUserProperties:(NSDictionary *)userProperties replace:(BOOL) replace {
     [self setUserProperties:userProperties];
 }
 
@@ -1331,7 +1331,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self setUserId:userId startNewSession:NO];
 }
 
-- (void)setUserId:(NSString *) userId startNewSession:(BOOL)startNewSession {
+- (void)setUserId:(NSString *)userId startNewSession:(BOOL)startNewSession {
     if (!(userId == nil || [self isArgument:userId validType:[NSString class] methodName:@"setUserId:"])) {
         return;
     }
@@ -1370,7 +1370,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (void)setServerUrl:(NSString *) serverUrl {
+- (void)setServerUrl:(NSString *)serverUrl {
     if (!(serverUrl == nil || [self isArgument:serverUrl validType:[NSString class] methodName:@"setServerUrl:"])) {
         return;
     }

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -557,7 +557,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     
     [self runOnBackgroundQueue:^{
         // Respect the opt-out setting by not sending or storing any events.
-        if ([self optOut])  {
+        if ([self optOut]) {
             AMPLITUDE_LOG(@"User has opted out of tracking. Event %@ not logged.", eventType);
             return;
         }
@@ -779,7 +779,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self runOnBackgroundQueue:^{
 
         // Don't communicate with the server if the user has opted out.
-        if ([self optOut] || self->_offline)  {
+        if ([self optOut] || self->_offline) {
             self->_updatingCurrently = NO;
             [self endBackgroundTaskIfNeeded];
             return;

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -382,7 +382,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (void)initializeApiKey:(NSString *)apiKey {
-    [self initializeApiKey:apiKey userId:nil setUserId: NO];
+    [self initializeApiKey:apiKey userId:nil setUserId:NO];
 }
 
 /**
@@ -390,7 +390,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
  */
 - (void)initializeApiKey:(NSString *)apiKey
                   userId:(NSString *)userId {
-    [self initializeApiKey:apiKey userId:userId setUserId: YES];
+    [self initializeApiKey:apiKey userId:userId setUserId:YES];
 }
 
 /**
@@ -896,10 +896,10 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             }
         }
 
-        [mergedEvents addObject: event != nil ? event : identify];
+        [mergedEvents addObject:event != nil ? event : identify];
     }
 
-    NSDictionary *results = [[NSDictionary alloc] initWithObjectsAndKeys: mergedEvents, EVENTS, [NSNumber numberWithLongLong:maxEventId], MAX_EVENT_ID, [NSNumber numberWithLongLong:maxIdentifyId], MAX_IDENTIFY_ID, nil];
+    NSDictionary *results = [[NSDictionary alloc] initWithObjectsAndKeys:mergedEvents, EVENTS, [NSNumber numberWithLongLong:maxEventId], MAX_EVENT_ID, [NSNumber numberWithLongLong:maxIdentifyId], MAX_IDENTIFY_ID, nil];
     return results;
 }
 
@@ -924,8 +924,8 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     // Add checksum
     [postData appendData:[@"&checksum=" dataUsingEncoding:NSUTF8StringEncoding]];
-    NSString *checksumData = [NSString stringWithFormat: @"%@%@%@%@", apiVersionString, self.apiKey, events, timestampString];
-    NSString *checksum = [self md5HexDigest: checksumData];
+    NSString *checksumData = [NSString stringWithFormat:@"%@%@%@%@", apiVersionString, self.apiKey, events, timestampString];
+    NSString *checksum = [self md5HexDigest:checksumData];
     [postData appendData:[checksum dataUsingEncoding:NSUTF8StringEncoding]];
 
     [request setHTTPMethod:@"POST"];
@@ -975,10 +975,10 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
                 // If blocked by one massive event, drop it
                 if (numEvents == 1) {
                     if (maxEventId >= 0) {
-                        (void) [self.dbHelper removeEvent: maxEventId];
+                        (void) [self.dbHelper removeEvent:maxEventId];
                     }
                     if (maxIdentifyId >= 0) {
-                        (void) [self.dbHelper removeIdentifys: maxIdentifyId];
+                        (void) [self.dbHelper removeIdentifys:maxIdentifyId];
                     }
                 }
 
@@ -1484,7 +1484,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     if ([obj isKindOfClass:[NSString class]]) {
         obj = (NSString *)obj;
         if ([obj length] > kAMPMaxStringLength) {
-            obj = [obj substringWithRange: [obj rangeOfComposedCharacterSequencesForRange: NSMakeRange(0, kAMPMaxStringLength)]];
+            obj = [obj substringWithRange:[obj rangeOfComposedCharacterSequencesForRange:NSMakeRange(0, kAMPMaxStringLength)]];
         }
     } else if ([obj isKindOfClass:[NSArray class]]) {
         NSMutableArray *arr = [NSMutableArray array];
@@ -1576,7 +1576,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
  */
 - (BOOL)upgradePrefs {
     // Copy any old data files to new file paths
-    NSString *oldEventsDataDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex: 0];
+    NSString *oldEventsDataDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     NSString *oldPropertyListPath = [oldEventsDataDirectory stringByAppendingPathComponent:@"com.amplitude.plist"];
     NSString *oldEventsDataPath = [oldEventsDataDirectory stringByAppendingPathComponent:@"com.amplitude.archiveDict"];
     BOOL success = [self moveFileIfNotExists:oldPropertyListPath to:_propertyListPath];

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -509,7 +509,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logEvent:eventType withEventProperties:eventProperties withGroups:nil];
 }
 
-- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties outOfSession:(BOOL) outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:nil outOfSession:outOfSession];
 }
 
@@ -521,7 +521,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:nil outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withGroups:(NSDictionary *)groups withLongLongTimestamp:(long long) timestamp outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withGroups:(NSDictionary *)groups withLongLongTimestamp:(long long)timestamp outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:[NSNumber numberWithLongLong:timestamp] outOfSession:outOfSession];
 }
 
@@ -529,7 +529,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:timestamp outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withApiProperties:(NSDictionary *)apiProperties withUserProperties:(NSDictionary *)userProperties withGroups:(NSDictionary *)groups withGroupProperties:(NSDictionary *)groupProperties withTimestamp:(NSNumber *)timestamp outOfSession:(BOOL) outOfSession {
+- (void)logEvent:(NSString *)eventType withEventProperties:(NSDictionary *)eventProperties withApiProperties:(NSDictionary *)apiProperties withUserProperties:(NSDictionary *)userProperties withGroups:(NSDictionary *)groups withGroupProperties:(NSDictionary *)groupProperties withTimestamp:(NSNumber *)timestamp outOfSession:(BOOL)outOfSession {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logEvent");
         return;
@@ -695,12 +695,12 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logRevenue:nil quantity:1 price:amount];
 }
 
-- (void)logRevenue:(NSString *)productIdentifier quantity:(NSInteger) quantity price:(NSNumber *)price
+- (void)logRevenue:(NSString *)productIdentifier quantity:(NSInteger)quantity price:(NSNumber *)price
 {
     [self logRevenue:productIdentifier quantity:quantity price:price receipt:nil];
 }
 
-- (void)logRevenue:(NSString *)productIdentifier quantity:(NSInteger) quantity price:(NSNumber *)price receipt:(NSData *)receipt
+- (void)logRevenue:(NSString *)productIdentifier quantity:(NSInteger)quantity price:(NSNumber *)price receipt:(NSData *)receipt
 {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logRevenue:");
@@ -903,7 +903,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return results;
 }
 
-- (void)makeEventUploadPostRequest:(NSString *)url events:(NSString *)events numEvents:(long) numEvents maxEventId:(long long) maxEventId maxIdentifyId:(long long) maxIdentifyId {
+- (void)makeEventUploadPostRequest:(NSString *)url events:(NSString *)events numEvents:(long)numEvents maxEventId:(long long)maxEventId maxIdentifyId:(long long)maxIdentifyId {
     NSMutableURLRequest *request =[NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     [request setTimeoutInterval:60.0];
 
@@ -1197,7 +1197,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self setLastEventTime:timestamp];
 }
 
-- (void)setPreviousSessionId:(long long) previousSessionId {
+- (void)setPreviousSessionId:(long long)previousSessionId {
     NSNumber *value = [NSNumber numberWithLongLong:previousSessionId];
     (void) [self.dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_ID value:value];
 }
@@ -1222,7 +1222,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self identify:identify outOfSession:NO];
 }
 
-- (void)identify:(AMPIdentify *)identify outOfSession:(BOOL) outOfSession {
+- (void)identify:(AMPIdentify *)identify outOfSession:(BOOL)outOfSession {
     if (identify == nil || [identify.userPropertyOperations count] == 0) {
         return;
     }
@@ -1233,7 +1233,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self groupIdentifyWithGroupType:groupType groupName:groupName groupIdentify:groupIdentify outOfSession:NO];
 }
 
-- (void)groupIdentifyWithGroupType:(NSString *)groupType groupName:(NSObject *)groupName groupIdentify:(AMPIdentify *)groupIdentify outOfSession:(BOOL) outOfSession {
+- (void)groupIdentifyWithGroupType:(NSString *)groupType groupName:(NSObject *)groupName groupIdentify:(AMPIdentify *)groupIdentify outOfSession:(BOOL)outOfSession {
     if (groupIdentify == nil || [groupIdentify.userPropertyOperations count] == 0) {
         return;
     }
@@ -1273,7 +1273,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 // maintain for legacy
 // replace argument is deprecated. In earlier versions of this SDK, this replaced the in-memory userProperties dictionary with the input, but now userProperties are no longer stored in memory.
-- (void)setUserProperties:(NSDictionary *)userProperties replace:(BOOL) replace {
+- (void)setUserProperties:(NSDictionary *)userProperties replace:(BOOL)replace {
     [self setUserProperties:userProperties];
 }
 
@@ -1386,7 +1386,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     self->_token = token;
 }
 
-- (void)setEventUploadMaxBatchSize:(int) eventUploadMaxBatchSize {
+- (void)setEventUploadMaxBatchSize:(int)eventUploadMaxBatchSize {
     _eventUploadMaxBatchSize = eventUploadMaxBatchSize;
     _backoffUploadBatchSize = eventUploadMaxBatchSize;
 }
@@ -1522,7 +1522,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return obj;
 }
 
-- (BOOL)isArgument:(id) argument validType:(Class) class methodName:(NSString *)methodName {
+- (BOOL)isArgument:(id)argument validType:(Class)class methodName:(NSString *)methodName {
     if ([argument isKindOfClass:class]) {
         return YES;
     } else {

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -146,7 +146,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [Amplitude instanceWithName:nil];
 }
 
-+ (Amplitude *)instanceWithName:(NSString*)instanceName {
++ (Amplitude *)instanceWithName:(NSString *)instanceName {
     static NSMutableDictionary *_instances = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -176,7 +176,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [self initWithInstanceName:nil];
 }
 
-- (instancetype)initWithInstanceName:(NSString*)instanceName {
+- (instancetype)initWithInstanceName:(NSString *)instanceName {
     if ([AMPUtils isEmptyString:instanceName]) {
         instanceName = kAMPDefaultInstance;
     }
@@ -381,15 +381,15 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self removeObservers];
 }
 
-- (void)initializeApiKey:(NSString*)apiKey {
+- (void)initializeApiKey:(NSString *)apiKey {
     [self initializeApiKey:apiKey userId:nil setUserId: NO];
 }
 
 /**
  * Initialize Amplitude with a given apiKey and userId.
  */
-- (void)initializeApiKey:(NSString*)apiKey
-                  userId:(NSString*)userId {
+- (void)initializeApiKey:(NSString *)apiKey
+                  userId:(NSString *)userId {
     [self initializeApiKey:apiKey userId:userId setUserId: YES];
 }
 
@@ -501,35 +501,35 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 #pragma mark - logEvent
 
-- (void)logEvent:(NSString*) eventType {
+- (void)logEvent:(NSString *) eventType {
     [self logEvent:eventType withEventProperties:nil];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:nil];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties outOfSession:(BOOL) outOfSession {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties outOfSession:(BOOL) outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:nil outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties withGroups:(NSDictionary*) groups {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups {
     [self logEvent:eventType withEventProperties:eventProperties withGroups:groups outOfSession:NO];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties withGroups:(NSDictionary*) groups outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:nil outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties withGroups:(NSDictionary*) groups withLongLongTimestamp:(long long) timestamp outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups withLongLongTimestamp:(long long) timestamp outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:[NSNumber numberWithLongLong:timestamp] outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties withGroups:(NSDictionary*) groups withTimestamp:(NSNumber*) timestamp outOfSession:(BOOL)outOfSession {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withGroups:(NSDictionary *) groups withTimestamp:(NSNumber *) timestamp outOfSession:(BOOL)outOfSession {
     [self logEvent:eventType withEventProperties:eventProperties withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:nil withTimestamp:timestamp outOfSession:outOfSession];
 }
 
-- (void)logEvent:(NSString*) eventType withEventProperties:(NSDictionary*) eventProperties withApiProperties:(NSDictionary*) apiProperties withUserProperties:(NSDictionary*) userProperties withGroups:(NSDictionary*) groups withGroupProperties:(NSDictionary*) groupProperties withTimestamp:(NSNumber*) timestamp outOfSession:(BOOL) outOfSession {
+- (void)logEvent:(NSString *) eventType withEventProperties:(NSDictionary *) eventProperties withApiProperties:(NSDictionary *) apiProperties withUserProperties:(NSDictionary *) userProperties withGroups:(NSDictionary *) groups withGroupProperties:(NSDictionary *) groupProperties withTimestamp:(NSNumber *) timestamp outOfSession:(BOOL) outOfSession {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logEvent");
         return;
@@ -623,7 +623,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (void)annotateEvent:(NSMutableDictionary*) event {
+- (void)annotateEvent:(NSMutableDictionary *) event {
     [event setValue:self.userId forKey:@"user_id"];
     [event setValue:self.deviceId forKey:@"device_id"];
     if ([_appliedTrackingOptions shouldTrackPlatform]) {
@@ -690,17 +690,17 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 // amount is a double in units of dollars
 // ex. $3.99 would be passed as [NSNumber numberWithDouble:3.99]
-- (void)logRevenue:(NSNumber*) amount
+- (void)logRevenue:(NSNumber *) amount
 {
     [self logRevenue:nil quantity:1 price:amount];
 }
 
-- (void)logRevenue:(NSString*) productIdentifier quantity:(NSInteger) quantity price:(NSNumber*) price
+- (void)logRevenue:(NSString *) productIdentifier quantity:(NSInteger) quantity price:(NSNumber *) price
 {
     [self logRevenue:productIdentifier quantity:quantity price:price receipt:nil];
 }
 
-- (void)logRevenue:(NSString*) productIdentifier quantity:(NSInteger) quantity price:(NSNumber*) price receipt:(NSData*) receipt
+- (void)logRevenue:(NSString *) productIdentifier quantity:(NSInteger) quantity price:(NSNumber *) price receipt:(NSData *) receipt
 {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logRevenue:");
@@ -727,7 +727,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logEvent:kAMPRevenueEvent withEventProperties:nil withApiProperties:apiProperties withUserProperties:nil withGroups:nil withGroupProperties:nil withTimestamp:nil outOfSession:NO];
 }
 
-- (void)logRevenueV2:(AMPRevenue*) revenue {
+- (void)logRevenueV2:(AMPRevenue *) revenue {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before calling logRevenueV2");
         return;
@@ -848,7 +848,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return sequenceNumber;
 }
 
-- (NSDictionary*)mergeEventsAndIdentifys:(NSMutableArray*)events identifys:(NSMutableArray*)identifys numEvents:(long)numEvents {
+- (NSDictionary *)mergeEventsAndIdentifys:(NSMutableArray *)events identifys:(NSMutableArray *)identifys numEvents:(long)numEvents {
     NSMutableArray *mergedEvents = [[NSMutableArray alloc] init];
     long long maxEventId = -1;
     long long maxIdentifyId = -1;
@@ -903,7 +903,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return results;
 }
 
-- (void)makeEventUploadPostRequest:(NSString*) url events:(NSString*) events numEvents:(long) numEvents maxEventId:(long long) maxEventId maxIdentifyId:(long long) maxIdentifyId {
+- (void)makeEventUploadPostRequest:(NSString *) url events:(NSString *) events numEvents:(long) numEvents maxEventId:(long long) maxEventId maxIdentifyId:(long long) maxIdentifyId {
     NSMutableURLRequest *request =[NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     [request setTimeoutInterval:60.0];
 
@@ -949,7 +949,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 #endif
     [[[session sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         BOOL uploadSuccessful = NO;
-        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
         if (response != nil) {
             if ([httpResponse statusCode] == 200) {
                 NSString *result = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
@@ -1104,7 +1104,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
  *
  * Returns YES if a new session was created.
  */
-- (BOOL)startOrContinueSessionNSNumber:(NSNumber*) timestamp {
+- (BOOL)startOrContinueSessionNSNumber:(NSNumber *) timestamp {
     if (!_inForeground) {
         if ([self inSession]) {
             if ([self isWithinMinTimeBetweenSessions:timestamp]) {
@@ -1141,7 +1141,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [self startOrContinueSessionNSNumber:timestampNumber];
 }
 
-- (void)startNewSession:(NSNumber*)timestamp {
+- (void)startNewSession:(NSNumber *)timestamp {
     if (_trackingSessionEvents) {
         [self sendSessionEvent:kAMPSessionEndEvent];
     }
@@ -1152,7 +1152,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (void)sendSessionEvent:(NSString*)sessionEvent {
+- (void)sendSessionEvent:(NSString *)sessionEvent {
     if (self.apiKey == nil) {
         AMPLITUDE_ERROR(@"ERROR: apiKey cannot be nil or empty, set apiKey with initializeApiKey: before sending session event");
         return;
@@ -1172,7 +1172,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return _sessionId >= 0;
 }
 
-- (BOOL)isWithinMinTimeBetweenSessions:(NSNumber*) timestamp {
+- (BOOL)isWithinMinTimeBetweenSessions:(NSNumber *) timestamp {
     NSNumber *previousSessionTime = [self lastEventTime];
     long long timeDelta = [timestamp longLongValue] - [previousSessionTime longLongValue];
 
@@ -1190,7 +1190,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 /**
  * Update the session timer if there's a running session.
  */
-- (void)refreshSessionTime:(NSNumber*) timestamp {
+- (void)refreshSessionTime:(NSNumber *) timestamp {
     if (![self inSession]) {
         return;
     }
@@ -1210,11 +1210,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [previousSessionId longLongValue];
 }
 
-- (void)setLastEventTime:(NSNumber*)timestamp {
+- (void)setLastEventTime:(NSNumber *)timestamp {
     (void) [self.dbHelper insertOrReplaceKeyLongValue:PREVIOUS_SESSION_TIME value:timestamp];
 }
 
-- (NSNumber*)lastEventTime {
+- (NSNumber *)lastEventTime {
     return [self.dbHelper getLongValue:PREVIOUS_SESSION_TIME];
 }
 
@@ -1229,11 +1229,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [self logEvent:IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:identify.userPropertyOperations withGroups:nil withGroupProperties:nil withTimestamp:nil outOfSession:outOfSession];
 }
 
-- (void)groupIdentifyWithGroupType:(NSString*)groupType groupName:(NSObject*)groupName groupIdentify:(AMPIdentify *)groupIdentify {
+- (void)groupIdentifyWithGroupType:(NSString *)groupType groupName:(NSObject *)groupName groupIdentify:(AMPIdentify *)groupIdentify {
     [self groupIdentifyWithGroupType:groupType groupName:groupName groupIdentify:groupIdentify outOfSession:NO];
 }
 
-- (void)groupIdentifyWithGroupType:(NSString*)groupType groupName:(NSObject*)groupName groupIdentify:(AMPIdentify *)groupIdentify outOfSession:(BOOL) outOfSession {
+- (void)groupIdentifyWithGroupType:(NSString *)groupType groupName:(NSObject *)groupName groupIdentify:(AMPIdentify *)groupIdentify outOfSession:(BOOL) outOfSession {
     if (groupIdentify == nil || [groupIdentify.userPropertyOperations count] == 0) {
         return;
     }
@@ -1249,7 +1249,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 #pragma mark - configurations
 
-- (void)setUserProperties:(NSDictionary*) userProperties {
+- (void)setUserProperties:(NSDictionary *) userProperties {
     if (userProperties == nil || ![self isArgument:userProperties validType:[NSDictionary class] methodName:@"setUserProperties:"] || [userProperties count] == 0) {
         return;
     }
@@ -1273,7 +1273,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 // maintain for legacy
 // replace argument is deprecated. In earlier versions of this SDK, this replaced the in-memory userProperties dictionary with the input, but now userProperties are no longer stored in memory.
-- (void)setUserProperties:(NSDictionary*) userProperties replace:(BOOL) replace {
+- (void)setUserProperties:(NSDictionary *) userProperties replace:(BOOL) replace {
     [self setUserProperties:userProperties];
 }
 
@@ -1327,11 +1327,11 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     _apiPropertiesTrackingOptions = [_appliedTrackingOptions getApiPropertiesTrackingOption];
 }
 
-- (void)setUserId:(NSString*)userId {
+- (void)setUserId:(NSString *)userId {
     [self setUserId:userId startNewSession:NO];
 }
 
-- (void)setUserId:(NSString*) userId startNewSession:(BOOL)startNewSession {
+- (void)setUserId:(NSString *) userId startNewSession:(BOOL)startNewSession {
     if (!(userId == nil || [self isArgument:userId validType:[NSString class] methodName:@"setUserId:"])) {
         return;
     }
@@ -1370,7 +1370,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (void)setServerUrl:(NSString*) serverUrl {
+- (void)setServerUrl:(NSString *) serverUrl {
     if (!(serverUrl == nil || [self isArgument:serverUrl validType:[NSString class] methodName:@"setServerUrl:"])) {
         return;
     }
@@ -1395,7 +1395,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [[self.dbHelper getLongValue:OPT_OUT] boolValue];
 }
 
-- (void)setDeviceId:(NSString*)deviceId {
+- (void)setDeviceId:(NSString *)deviceId {
     if (![self isValidDeviceId:deviceId]) {
         return;
     }
@@ -1417,7 +1417,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 #pragma mark - Getters for device data
-- (NSString*)getAdSupportID {
+- (NSString *)getAdSupportID {
     NSString *result = nil;
     if (self.adSupportBlock != nil && [_appliedTrackingOptions shouldTrackIDFA]) {
         result = self.adSupportBlock();
@@ -1429,7 +1429,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return result;
 }
 
-- (NSString*)getDeviceId {
+- (NSString *)getDeviceId {
     return self.deviceId;
 }
 
@@ -1437,7 +1437,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return _sessionId;
 }
 
-- (NSString*)initializeDeviceId {
+- (NSString *)initializeDeviceId {
     if (self.deviceId == nil) {
         self.deviceId = [self.dbHelper getValue:DEVICE_ID];
         if (![self isValidDeviceId:self.deviceId]) {
@@ -1448,7 +1448,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return self.deviceId;
 }
 
-- (NSString*)_getDeviceId {
+- (NSString *)_getDeviceId {
     NSString *deviceId = nil;
     if (_useAdvertisingIdForDeviceId && [_appliedTrackingOptions shouldTrackIDFA]) {
         deviceId = [self getAdSupportID];
@@ -1466,7 +1466,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return [[NSString alloc] initWithString:deviceId];
 }
 
-- (BOOL)isValidDeviceId:(NSString*)deviceId {
+- (BOOL)isValidDeviceId:(NSString *)deviceId {
     if (deviceId == nil ||
         ![self isArgument:deviceId validType:[NSString class] methodName:@"isValidDeviceId"] ||
         [deviceId isEqualToString:@"e3f5536a141811db40efd6400f1d0a4e"] ||
@@ -1476,13 +1476,13 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return YES;
 }
 
-- (NSDictionary*)replaceWithEmptyJSON:(NSDictionary*)dictionary {
+- (NSDictionary *)replaceWithEmptyJSON:(NSDictionary *)dictionary {
     return dictionary == nil ? [NSMutableDictionary dictionary] : dictionary;
 }
 
 - (id) truncate:(id)obj {
     if ([obj isKindOfClass:[NSString class]]) {
-        obj = (NSString*)obj;
+        obj = (NSString *)obj;
         if ([obj length] > kAMPMaxStringLength) {
             obj = [obj substringWithRange: [obj rangeOfComposedCharacterSequencesForRange: NSMakeRange(0, kAMPMaxStringLength)]];
         }
@@ -1522,7 +1522,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return obj;
 }
 
-- (BOOL)isArgument:(id) argument validType:(Class) class methodName:(NSString*)methodName {
+- (BOOL)isArgument:(id) argument validType:(Class) class methodName:(NSString *)methodName {
     if ([argument isKindOfClass:class]) {
         return YES;
     } else {
@@ -1531,7 +1531,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (NSString*)md5HexDigest:(NSString*)input {
+- (NSString *)md5HexDigest:(NSString *)input {
     const char* str = [input UTF8String];
     unsigned char result[CC_MD5_DIGEST_LENGTH];
     
@@ -1551,12 +1551,12 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return ret;
 }
 
-- (NSString*)urlEncodeString:(NSString*)string {
+- (NSString *)urlEncodeString:(NSString *)string {
     NSCharacterSet * allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:@":/?#[]@!$ &'()*+,;=\"<>%{}|\\^~`"] invertedSet];
     return [string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
-- (NSDate*)currentTime {
+- (NSDate *)currentTime {
     return [NSDate date];
 }
 
@@ -1596,7 +1596,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (id)deserializePList:(NSString*)path {
+- (id)deserializePList:(NSString *)path {
     if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
         NSData *pListData = [[NSFileManager defaultManager] contentsAtPath:path];
         if (pListData != nil) {
@@ -1620,7 +1620,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return nil;
 }
 
-- (BOOL)serializePList:(id)data toFile:(NSString*)path {
+- (BOOL)serializePList:(id)data toFile:(NSString *)path {
     NSError *error = nil;
     NSData *propertyListData = [NSPropertyListSerialization
                                 dataWithPropertyList:data
@@ -1643,7 +1643,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 }
 
-- (id)unarchive:(NSString*)path {
+- (id)unarchive:(NSString *)path {
 #if !TARGET_OS_OSX
     // unarchive using new NSKeyedUnarchiver method from iOS 9.0 that doesn't throw exceptions
     if (@available(iOS 9.0, *)) {
@@ -1701,7 +1701,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (BOOL)archive:(id) obj toFile:(NSString*)path {
+- (BOOL)archive:(id)obj toFile:(NSString *)path {
     if (@available(tvOS 11.0, iOS 12, macOS 10.13, *)) {
         NSError *archiveError = nil;
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError];
@@ -1732,7 +1732,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 }
 
-- (BOOL)moveFileIfNotExists:(NSString*)from to:(NSString*)to {
+- (BOOL)moveFileIfNotExists:(NSString *)from to:(NSString *)to {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *error;
     if (![fileManager fileExistsAtPath:to] &&

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -77,7 +77,7 @@
 #import "AMPEventExplorer.h"
 #endif
 
-@interface Amplitude()
+@interface Amplitude ()
 
 @property (nonatomic, strong) NSOperationQueue *backgroundQueue;
 @property (nonatomic, strong) NSOperationQueue *initializerQueue;

--- a/Sources/Amplitude/ISPCertificatePinning.h
+++ b/Sources/Amplitude/ISPCertificatePinning.h
@@ -44,7 +44,7 @@
  @return BOOL successfully loaded the public keys and domains
 
  */
-+ (BOOL)setupSSLPinsUsingDictionnary:(NSDictionary*)domainsAndCertificates;
++ (BOOL)setupSSLPinsUsingDictionnary:(NSDictionary *)domainsAndCertificates;
 
 
 /**
@@ -61,7 +61,7 @@
  @return BOOL found the domain's pinned certificate in the trust object's certificate chain
 
  */
-+ (BOOL)verifyPinnedCertificateForTrust:(SecTrustRef)trust andDomain:(NSString*)domain;
++ (BOOL)verifyPinnedCertificateForTrust:(SecTrustRef)trust andDomain:(NSString *)domain;
 
 @end
 #endif

--- a/Sources/Amplitude/ISPCertificatePinning.m
+++ b/Sources/Amplitude/ISPCertificatePinning.m
@@ -102,7 +102,7 @@
 
             // Extract the certificate
             SecCertificateRef certificate = SecTrustGetCertificateAtIndex(trust, i);
-            NSData* DERCertificate = (__bridge NSData *)SecCertificateCopyData(certificate);
+            NSData *DERCertificate = (__bridge NSData *)SecCertificateCopyData(certificate);
 
             // Compare the two certificates
             if ([pinnedCertificate isEqualToData:DERCertificate]) {

--- a/Sources/Amplitude/ISPCertificatePinning.m
+++ b/Sources/Amplitude/ISPCertificatePinning.m
@@ -102,7 +102,7 @@
 
             // Extract the certificate
             SecCertificateRef certificate = SecTrustGetCertificateAtIndex(trust, i);
-            NSData* DERCertificate = (__bridge NSData *) SecCertificateCopyData(certificate);
+            NSData* DERCertificate = (__bridge NSData *)SecCertificateCopyData(certificate);
 
             // Compare the two certificates
             if ([pinnedCertificate isEqualToData:DERCertificate]) {

--- a/Sources/Amplitude/ISPCertificatePinning.m
+++ b/Sources/Amplitude/ISPCertificatePinning.m
@@ -44,7 +44,7 @@
 
 
 
-+ (BOOL)setupSSLPinsUsingDictionnary:(NSDictionary*)domainsAndCertificates {
++ (BOOL)setupSSLPinsUsingDictionnary:(NSDictionary *)domainsAndCertificates {
     if (domainsAndCertificates == nil) {
         return NO;
     }
@@ -73,7 +73,7 @@
 }
 
 
-+ (BOOL)verifyPinnedCertificateForTrust:(SecTrustRef)trust andDomain:(NSString*)domain {
++ (BOOL)verifyPinnedCertificateForTrust:(SecTrustRef)trust andDomain:(NSString *)domain {
     if ((trust == NULL) || (domain == nil)) {
         return NO;
     }
@@ -102,7 +102,7 @@
 
             // Extract the certificate
             SecCertificateRef certificate = SecTrustGetCertificateAtIndex(trust, i);
-            NSData* DERCertificate = (__bridge NSData*) SecCertificateCopyData(certificate);
+            NSData* DERCertificate = (__bridge NSData *) SecCertificateCopyData(certificate);
 
             // Compare the two certificates
             if ([pinnedCertificate isEqualToData:DERCertificate]) {

--- a/Sources/Amplitude/ISPPinnedNSURLConnectionDelegate.m
+++ b/Sources/Amplitude/ISPPinnedNSURLConnectionDelegate.m
@@ -35,12 +35,12 @@
             }
             else {
                 // The certificate wasn't found in the certificate chain; cancel the connection
-                [[challenge sender] cancelAuthenticationChallenge: challenge];
+                [[challenge sender] cancelAuthenticationChallenge:challenge];
             }
         }
         else {
             // Certificate chain validation failed; cancel the connection
-            [[challenge sender] cancelAuthenticationChallenge: challenge];
+            [[challenge sender] cancelAuthenticationChallenge:challenge];
         }
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
This PR unifies the use of whitespaces
- in interface and category declarations
```
@interface Foo : NSObject
@interface Foo ()
@interface Foo (CategoryName)
```
- in implementation declarations:
```
// Without ivars
@implementation Foo

// With ivars
@implementation Foo {
    Bar *_bar;
}
```
- in method declarations
```
- (Foo *)createFooFromBar:(Bar *)bar andBaz:(Baz *)baz;
- (Foo)createFooFromBar:(Bar)bar andBar:(Baz)baz;
```
- in method calls
```
[Foo doSomethingWithBar:bar andBaz:baz];
```
- in type casts
```
... = (Foo *)bar;
... = (Bar)baz;
```
- in variable declarations
```
Foo *foo = ...
```

Apart from that, it fixes
- two instances where there were two whitespaces between the `)` and the `{` of a conditional
- one instance where a whitespace was missing between the `)` and the `{` of a conditional

---

To have some additional corroboration that this PR includes only whitespace changes,  
you can hide whitespace changes when reviewing it on github:

![image](https://user-images.githubusercontent.com/11081921/96716574-82cdf780-13a5-11eb-9af2-d6a0d40fc542.png)

It should then show "Whitespace only changes" for all files except for AMPRevenue.m,  
where I removed a pair of empty curly braces after the implementation declaration.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
