### PR TITLE
fix: macOS 10.11/10.13 compile warning fix

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1691,7 +1691,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#pragma clang diagnostic ignored "-Wunguarded-availability" // Unarchive only called within context of macOS > 10.11
+#pragma clang diagnostic ignored "-Wunguarded-availability" // Safe to use this flag since API only used with macOS > 10.11 from (id)unarchive:(NSString*)path 
         // Even with the availability check above, Xcode would still emit a deprecation warning here.
         // Since there's no way that it could be reached on iOS's >= 12.0 or tvOS's >= 11.0
         // (where `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData:error:]` was deprecated),

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1686,8 +1686,8 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (id)unarchive:(NSData *)data error:(NSError **)error {
-    if (@available(iOS 12, tvOS 11.0, *)) {
-        return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error];
+    if (@available(iOS 12, tvOS 11.0, macOS 10.13, *)) {
+        return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error]; // warn 10.13
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -1695,15 +1695,15 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         // Since there's no way that it could be reached on iOS's >= 12.0 or tvOS's >= 11.0
         // (where `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData:error:]` was deprecated),
         // we simply ignore the warning.
-        return [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:error];
+        return [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:error]; // warn 10.11
 #pragma clang diagnostic pop
     }
 }
 
 - (BOOL)archive:(id) obj toFile:(NSString*)path {
-    if (@available(tvOS 11.0, iOS 12, *)) {
+    if (@available(tvOS 11.0, iOS 12, macOS 10.13, *)) {
         NSError *archiveError = nil;
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError];
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError]; // warn 10.13
         if (archiveError != nil) {
             AMPLITUDE_ERROR(@"ERROR: Unable to archive object %@: %@", obj, archiveError);
             return NO;

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1691,6 +1691,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunguarded-availability" // Unarchive only called within context of macOS > 10.11
         // Even with the availability check above, Xcode would still emit a deprecation warning here.
         // Since there's no way that it could be reached on iOS's >= 12.0 or tvOS's >= 11.0
         // (where `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData:error:]` was deprecated),

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1687,7 +1687,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (id)unarchive:(NSData *)data error:(NSError **)error {
     if (@available(iOS 12, tvOS 11.0, macOS 10.13, *)) {
-        return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error]; // warn 10.13
+        return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error];
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -1696,7 +1696,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         // Since there's no way that it could be reached on iOS's >= 12.0 or tvOS's >= 11.0
         // (where `[NSKeyedUnarchiver unarchiveTopLevelObjectWithData:error:]` was deprecated),
         // we simply ignore the warning.
-        return [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:error]; // warn 10.11
+        return [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:error];
 #pragma clang diagnostic pop
     }
 }
@@ -1704,7 +1704,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 - (BOOL)archive:(id) obj toFile:(NSString*)path {
     if (@available(tvOS 11.0, iOS 12, macOS 10.13, *)) {
         NSError *archiveError = nil;
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError]; // warn 10.13
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError];
         if (archiveError != nil) {
             AMPLITUDE_ERROR(@"ERROR: Unable to archive object %@: %@", obj, archiveError);
             return NO;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- #301 introduced 3 compiler warnings when running `pod lib lint`
  - 2 fixed by adding macOS 10.13 to `@available` check 
  - 1 fixed by adding `-Wunguarded-availability` directive

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
