### PR TITLE
feat: Add setSessionId to public API

### DIFF
--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -642,9 +642,20 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
 
  @returns the current session id
 
- @see [Tracking Sessions](https://github.com/amplitude/Amplitude-iOS#tracking-sessions)
+ @see [Tracking Sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Tracking-Session)
  */
 - (long long)getSessionId;
+
+/**
+ Sets the sessionId.
+
+ **NOTE: not recommended unless you know what you are doing**
+
+ @param timestamp                  Timestamp representing the sessionId
+
+ @see [Tracking Sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Tracking-Session)
+ */
+- (void)setSessionId:(long long)timestamp;
 
 /**
  Manually forces the instance to immediately upload all unsent events.

--- a/Tests/SessionTests.m
+++ b/Tests/SessionTests.m
@@ -141,6 +141,11 @@
 
     // An out of session event should not continue the session
     XCTAssertEqual([[mockAmplitude lastEventTime] longLongValue], 3000000); // event time of first no session
+
+    // Test setSessionId
+    long testSessionId = 1337;
+    [mockAmplitude setSessionId:testSessionId];
+    XCTAssertEqual([mockAmplitude sessionId], testSessionId);
 }
 
 - (void)testEnterBackgroundDoesNotTrackEvent {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Add `setSessionId` to header
- Add tests for setting session id
- Closes #294 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/master/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> NO
