### PR TITLE
feat: Set content-type header for HTTP requests

### DIFF
--- a/Sources/Amplitude/AMPConstants.h
+++ b/Sources/Amplitude/AMPConstants.h
@@ -31,6 +31,7 @@ extern NSString *const kAMPPlatform;
 extern NSString *const kAMPOSName;
 extern NSString *const kAMPEventLogDomain;
 extern NSString *const kAMPEventLogUrl;
+extern NSString *const kAMPContentTypeHeader;
 extern NSString *const kAMPDyanmicConfigUrl;
 extern NSString *const kAMPDefaultInstance;
 extern const int kAMPApiVersion;

--- a/Sources/Amplitude/AMPConstants.m
+++ b/Sources/Amplitude/AMPConstants.m
@@ -29,6 +29,7 @@ NSString *const kAMPUnknownLibrary = @"unknown-library";
 NSString *const kAMPUnknownVersion = @"unknown-version";
 NSString *const kAMPEventLogDomain = @"api2.amplitude.com";
 NSString *const kAMPEventLogUrl = @"https://api2.amplitude.com/";
+NSString *const kAMPContentTypeHeader = @"application/x-www-form-urlencoded";
 NSString *const kAMPDyanmicConfigUrl = @"https://regionconfig.amplitude.com/";
 NSString *const kAMPDefaultInstance = @"$default_instance";
 const int kAMPApiVersion = 3;

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -607,6 +607,9 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
  */
 - (void)disableCoppaControl;
 
+/**
+ Sends events to a different URL other than kAMPEventLogUrl. Used for proxy servers
+ */
 - (void)setServerUrl:(NSString *)serverUrl;
 
 - (void)setBearerToken:(NSString *)token;

--- a/Sources/Amplitude/Amplitude.h
+++ b/Sources/Amplitude/Amplitude.h
@@ -176,6 +176,11 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
  */
 @property (nonatomic, strong, nullable) AMPLocationInfoBlock locationInfoBlock;
 
+/**
+ Content-Type header for event sending requests. Only relevant for sending events to a different URL (e.g. proxy server)
+ */
+@property (nonatomic, copy, readonly) NSString *contentTypeHeader;
+
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 /**
  Show Amplitude Event Explorer when you're running a debug build.
@@ -612,6 +617,11 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
  */
 - (void)setServerUrl:(NSString *)serverUrl;
 
+/**
+ Sets Content-Type header for event sending requests
+*/
+- (void)setContentTypeHeader:(NSString *)contentType;
+
 - (void)setBearerToken:(NSString *)token;
 
 /**-----------------------------------------------------------------------------
@@ -671,6 +681,9 @@ typedef NSDictionary *_Nullable (^AMPLocationInfoBlock)(void);
  Call to check if the SDK is ready to start a new session at timestamp. Returns YES if a new session was started, otherwise NO and current session is extended. Only use if you know what you are doing. Recommended to use current time in UTC milliseconds for timestamp.
  */
 - (BOOL)startOrContinueSession:(long long)timestamp;
+
+
+- (NSString *)getContentTypeHeader;
 
 @end
 

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -89,6 +89,7 @@
 @property (nonatomic, assign) int backoffUploadBatchSize;
 @property (nonatomic, copy, readwrite, nullable) NSString *userId;
 @property (nonatomic, copy, readwrite) NSString *deviceId;
+@property (nonatomic, copy, readwrite) NSString *contentTypeHeader;
 #if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 @property (nonatomic, strong) AMPEventExplorer *eventExplorer;
 #endif
@@ -929,7 +930,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     [postData appendData:[checksum dataUsingEncoding:NSUTF8StringEncoding]];
 
     [request setHTTPMethod:@"POST"];
-    [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    [request setValue:self.contentTypeHeader forHTTPHeaderField:@"Content-Type"];
     [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[postData length]] forHTTPHeaderField:@"Content-Length"];
 
     if (_token != nil) {
@@ -1377,6 +1378,14 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     self->_serverUrl = serverUrl;
 }
+
+- (void)setContentTypeHeader:(NSString *)contentTypeHeader {
+   self->_contentTypeHeader = contentTypeHeader;
+}
+
+- (NSString *)getContentTypeHeader {
+    return self.contentTypeHeader;
+  }
 
 - (void)setBearerToken:(NSString *)token {
     if (!(token == nil || [self isArgument:token validType:[NSString class] methodName:@"setBearerToken:"])) {

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -201,6 +201,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         _serverUrl = kAMPEventLogUrl;
         self.libraryName = kAMPLibrary;
         self.libraryVersion = kAMPVersion;
+        self.contentTypeHeader = kAMPContentTypeHeader;
         _inputTrackingOptions = [AMPTrackingOptions options];
         _appliedTrackingOptions = [AMPTrackingOptions copyOf:_inputTrackingOptions];
         _apiPropertiesTrackingOptions = [NSDictionary dictionary];


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Make default `application/x-www-form-urlencoded` value a constant
- delet

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
