### PR TITLE
feat(podspec): Add defines modules to podspec for React Native support

### DIFF
--- a/Amplitude.podspec
+++ b/Amplitude.podspec
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.source                 = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v#{s.version}" }
   s.requires_arc           = true
   s.library                = 'sqlite3.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  
+
   s.ios.deployment_target  = '10.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,m}'
   s.ios.resources          = 'Sources/Amplitude/**/*.{der}'
@@ -27,4 +26,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target  = '3.0'
   s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,m}'
   s.watchos.resources          = 'Sources/Amplitude/**/*.{der}'
+
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Amplitude.podspec
+++ b/Amplitude.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.source                 = { :git => "https://github.com/amplitude/Amplitude-iOS.git", :tag => "v#{s.version}" }
   s.requires_arc           = true
   s.library                = 'sqlite3.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   
   s.ios.deployment_target  = '10.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,m}'


### PR DESCRIPTION
### Summary

Adds ` s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }` to the podspec file.

### Checklist

* [X ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
