### PR TITLE
fix: Changed the new resources path in podspec file to fix Cocoapods

### DIFF
--- a/Amplitude.podspec
+++ b/Amplitude.podspec
@@ -13,19 +13,19 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target  = '10.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.ios.resources          = 'Sources/Amplitude/**/*.{der}'
+  s.ios.resources          = 'Sources/Resources/*.{der}'
 
   s.tvos.deployment_target = '9.0'
   s.tvos.source_files      = 'Sources/Amplitude/**/*.{h,m}'
-  s.tvos.resources         = 'Sources/Amplitude/**/*.{der}'
+  s.tvos.resources         = 'Sources/Resources/*.{der}'
 
   s.osx.deployment_target  = '10.10'
   s.osx.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.osx.resources          = 'Sources/Amplitude/**/*.{der}'
+  s.osx.resources          = 'Sources/Resources/*.{der}'
 
   s.watchos.deployment_target  = '3.0'
   s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.watchos.resources          = 'Sources/Amplitude/**/*.{der}'
+  s.watchos.resources          = 'Sources/Resources/*.{der}'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end


### PR DESCRIPTION
### Summary

I broke the Cocoapods integration in: https://github.com/amplitude/Amplitude-iOS/pull/335. Oops. Here I edited the podspec file to fix it.

`pod lib lint` should now pass:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/4634735/113343181-7a3aff00-92fd-11eb-8698-bb67bcad17ae.png">

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
