### PR TITLE
fix: Add watchOS scheme for building with Carthage

### DIFF
--- a/Amplitude.xcodeproj/xcshareddata/xcschemes/Amplitude_watchOS.xcscheme
+++ b/Amplitude.xcodeproj/xcshareddata/xcschemes/Amplitude_watchOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "759E937925FBF2BB00BF7C3D"
+               BuildableName = "Amplitude.framework"
+               BlueprintName = "Amplitude_watchOS"
+               ReferencedContainer = "container:Amplitude.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "759E937925FBF2BB00BF7C3D"
+            BuildableName = "Amplitude.framework"
+            BlueprintName = "Amplitude_watchOS"
+            ReferencedContainer = "container:Amplitude.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Framework/AmplitudeFramework.h
+++ b/Framework/AmplitudeFramework.h
@@ -4,3 +4,7 @@
 #import <Amplitude/AMPRevenue.h>
 #import <Amplitude/AMPTrackingOptions.h>
 #import <Amplitude/Amplitude+SSLPinning.h>
+
+#if TARGET_OS_WATCH
+#import <Amplitude/AMPBackgroundNotifier.h>
+#endif


### PR DESCRIPTION
### Summary

Hey folks, this PR builds on #330 by adding a new shared scheme to the project for building the watchOS framework with Carthage. It also adds the newly created `AMPBackgroundNotifier` to the umbrella header when targeting watchOS.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
