### PR TITLE
fix: show correct device info for ios app runs on M1 mac

### DIFF
--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -188,17 +188,29 @@
 }
 
 + (NSString *)getPlatformString {
-#if !TARGET_OS_OSX
-    BOOL isiOSAppOnMac = false;
-    const char *sysctl_name = "hw.machine";
-    if (@available(iOS 14.0, *) || @available(tvOS 14.0, *) || @available(watchOS 7.0, *)) {
+    const char *sysctl_name = "hw.model";
+    BOOL isiOSAppOnMac = NO;
+#if TARGET_OS_IOS
+    if (@available(iOS 14.0, *)) {
         isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
     }
-    if (isiOSAppOnMac){
-        sysctl_name = "hw.model";
+    if (!isiOSAppOnMac){
+        sysctl_name = "hw.machine";
     }
-#else
-    const char *sysctl_name = "hw.model";
+#elif TARGET_OS_TV
+    if (@available(tvOS 14.0, *)) {
+        isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
+    }
+    if (!isiOSAppOnMac){
+        sysctl_name = "hw.machine";
+    }
+#elif TARGET_OS_WATCH
+    if (@available(watchOS 7.0, *)) {
+        isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
+    }
+    if (!isiOSAppOnMac){
+        sysctl_name = "hw.machine";
+    }
 #endif
     size_t size;
     sysctlbyname(sysctl_name, NULL, &size, NULL, 0);

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -189,7 +189,15 @@
 
 + (NSString *)getPlatformString {
 #if !TARGET_OS_OSX
-    const char *sysctl_name = "hw.machine";
+    BOOL isiOSAppOnMac = false;
+    if (@available(iOS 14.0, *)) {
+        isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
+    }
+    if (isiOSAppOnMac){
+        const char *sysctl_name = "hw.model";
+    } else {
+        const char *sysctl_name = "hw.machine";
+    }
 #else
     const char *sysctl_name = "hw.model";
 #endif

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -189,28 +189,16 @@
 
 + (NSString *)getPlatformString {
     const char *sysctl_name = "hw.model";
-    BOOL isiOSAppOnMac = NO;
 #if TARGET_OS_IOS
+    BOOL isiOSAppOnMac = NO;
     if (@available(iOS 14.0, *)) {
         isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
     }
     if (!isiOSAppOnMac){
         sysctl_name = "hw.machine";
     }
-#elif TARGET_OS_TV
-    if (@available(tvOS 14.0, *)) {
-        isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
-    }
-    if (!isiOSAppOnMac){
-        sysctl_name = "hw.machine";
-    }
-#elif TARGET_OS_WATCH
-    if (@available(watchOS 7.0, *)) {
-        isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
-    }
-    if (!isiOSAppOnMac){
-        sysctl_name = "hw.machine";
-    }
+#elif TARGET_OS_TV || TARGET_OS_WATCH
+    sysctl_name = "hw.machine";
 #endif
     size_t size;
     sysctlbyname(sysctl_name, NULL, &size, NULL, 0);

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -190,13 +190,12 @@
 + (NSString *)getPlatformString {
 #if !TARGET_OS_OSX
     BOOL isiOSAppOnMac = false;
+    const char *sysctl_name = "hw.machine";
     if (@available(iOS 14.0, *)) {
         isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
     }
     if (isiOSAppOnMac){
-        const char *sysctl_name = "hw.model";
-    } else {
-        const char *sysctl_name = "hw.machine";
+        sysctl_name = "hw.model";
     }
 #else
     const char *sysctl_name = "hw.model";

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -191,7 +191,7 @@
 #if !TARGET_OS_OSX
     BOOL isiOSAppOnMac = false;
     const char *sysctl_name = "hw.machine";
-    if (@available(iOS 14.0, *)) {
+    if (@available(iOS 14.0, *) || @available(tvOS 14.0, *) || @available(watchOS 7.0, *)) {
         isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
     }
     if (isiOSAppOnMac){


### PR DESCRIPTION


### Summary

Mac with M1 CPU can run ios app, the hw.machine will return iPad platform tag. In the getPlatformString method, added a boolean value isiOSAppOnMac, if it's true and target os is not osx, use hw.model instead of hw.machine.

### Checklist

* [X ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <no>
