### PR TITLE
fix: -[AMPIdentify set:value:] does not overwrite value of existing property per documented behaviour

### DIFF
--- a/Sources/Amplitude/AMPIdentify.m
+++ b/Sources/Amplitude/AMPIdentify.m
@@ -130,8 +130,19 @@
 
     // Check if property was already used in a previous operation.
     if ([_userProperties containsObject:property]) {
-        AMPLITUDE_LOG(@"Already used property '%@' in previous operation, ignoring for operation '%@'", property, operation);
-        return;
+        // Overwrite previous $set value if present
+        BOOL shouldOverwriteProperty = NO;
+        if ([operation isEqualToString:AMP_OP_SET]) {
+            NSMutableDictionary *setOperations = [_userPropertyOperations objectForKey:AMP_OP_SET];
+            if (setOperations[property] != nil) {
+                shouldOverwriteProperty = YES;
+            }
+        }
+        
+        if (shouldOverwriteProperty == NO) {
+            AMPLITUDE_LOG(@"Already used property '%@' in previous operation, ignoring for operation '%@'", property, operation);
+            return;
+        }
     }
 
     NSMutableDictionary *operations = [_userPropertyOperations objectForKey:operation];


### PR DESCRIPTION
### Summary

This fixes https://github.com/amplitude/Amplitude-iOS/issues/387

### Checklist

* Does your PR have a breaking change?:  no
