### PR TITLE
fix: IDENTIFY_EVENT renamed to prevent symbol collision

### DIFF
--- a/Sources/Amplitude/AMPConstants.h
+++ b/Sources/Amplitude/AMPConstants.h
@@ -48,8 +48,8 @@ extern const long kAMPMinTimeBetweenSessionsMillis;
 extern const int kAMPMaxStringLength;
 extern const int kAMPMaxPropertyKeys;
 
-extern NSString *const IDENTIFY_EVENT;
-extern NSString *const GROUP_IDENTIFY_EVENT;
+extern NSString *const AMP_IDENTIFY_EVENT;
+extern NSString *const AMP_GROUP_IDENTIFY_EVENT;
 extern NSString *const AMP_OP_ADD;
 extern NSString *const AMP_OP_APPEND;
 extern NSString *const AMP_OP_CLEAR_ALL;

--- a/Sources/Amplitude/AMPConstants.m
+++ b/Sources/Amplitude/AMPConstants.m
@@ -72,8 +72,8 @@ const long kAMPMinTimeBetweenSessionsMillis = 5 * 60 * 1000; // 5 minutes
 const int kAMPMaxStringLength = 1024;
 const int kAMPMaxPropertyKeys = 1000;
 
-NSString *const IDENTIFY_EVENT = @"$identify";
-NSString *const GROUP_IDENTIFY_EVENT = @"$groupidentify";
+NSString *const AMP_IDENTIFY_EVENT = @"$identify";
+NSString *const AMP_GROUP_IDENTIFY_EVENT = @"$groupidentify";
 NSString *const AMP_OP_ADD = @"$add";
 NSString *const AMP_OP_APPEND = @"$append";
 NSString *const AMP_OP_CLEAR_ALL = @"$clearAll";

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -632,14 +632,14 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             AMPLITUDE_ERROR(@"ERROR: JSONSerializing event type %@ resulted in an NULL string", eventType);
             return;
         }
-        if ([eventType isEqualToString:IDENTIFY_EVENT] || [eventType isEqualToString:GROUP_IDENTIFY_EVENT]) {
+        if ([eventType isEqualToString:AMP_IDENTIFY_EVENT] || [eventType isEqualToString:AMP_GROUP_IDENTIFY_EVENT]) {
             (void) [self.dbHelper addIdentify:jsonString];
         } else {
             (void) [self.dbHelper addEvent:jsonString];
         }
         
         // Apply identify events to amplitude core to notify experiment SDK that user properties have changed.
-        if ([eventType isEqualToString:IDENTIFY_EVENT]) {
+        if ([eventType isEqualToString:AMP_IDENTIFY_EVENT]) {
             id<IdentityStoreEditor> editor = [[[AnalyticsConnector getInstance:self.instanceName] identityStore] editIdentity];
             [[editor updateUserProperties:[event valueForKey:@"user_properties"]] commit];
         }
@@ -1276,7 +1276,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     if (identify == nil || [identify.userPropertyOperations count] == 0) {
         return;
     }
-    [self logEvent:IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:identify.userPropertyOperations withGroups:nil withGroupProperties:nil withTimestamp:nil outOfSession:outOfSession];
+    [self logEvent:AMP_IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:identify.userPropertyOperations withGroups:nil withGroupProperties:nil withTimestamp:nil outOfSession:outOfSession];
 }
 
 - (void)groupIdentifyWithGroupType:(NSString *)groupType groupName:(NSObject *)groupName groupIdentify:(AMPIdentify *)groupIdentify {
@@ -1294,7 +1294,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     }
 
     NSMutableDictionary *groups = [NSMutableDictionary dictionaryWithObjectsAndKeys:groupName, groupType, nil];
-    [self logEvent:GROUP_IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:groupIdentify.userPropertyOperations withTimestamp:nil outOfSession:outOfSession];
+    [self logEvent:AMP_GROUP_IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:nil withGroups:groups withGroupProperties:groupIdentify.userPropertyOperations withTimestamp:nil outOfSession:outOfSession];
 }
 
 #pragma mark - configurations
@@ -1345,7 +1345,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     NSMutableDictionary *groups = [NSMutableDictionary dictionaryWithObjectsAndKeys:groupName, groupType, nil];
     AMPIdentify *identify = [[AMPIdentify identify] set:groupType value:groupName];
-    [self logEvent:IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:identify.userPropertyOperations withGroups:groups withGroupProperties:nil withTimestamp:nil outOfSession:NO];
+    [self logEvent:AMP_IDENTIFY_EVENT withEventProperties:nil withApiProperties:nil withUserProperties:identify.userPropertyOperations withGroups:groups withGroupProperties:nil withTimestamp:nil outOfSession:NO];
 
 }
 


### PR DESCRIPTION
### Summary

When we compile Amplitude and Rakam and we link them statically we have a symbol collision as shown in this image:

<img width="1065" alt="Captura de Pantalla 2022-03-30 a la(s) 12 40 12" src="https://user-images.githubusercontent.com/6267487/160935753-8daf6e91-0677-4591-912f-29002b4b93f9.png">

This causes that the linker selects one of the two, in this example it selected Rakam's one: `$$user`

<img width="1194" alt="Captura de Pantalla 2022-03-30 a la(s) 12 38 02" src="https://user-images.githubusercontent.com/6267487/160935927-60114159-6487-4b57-b95f-c749877d62f3.png">

This is causing us that Amplitude considers it as any other event instead of setting user properties:

<img width="529" alt="Captura de Pantalla 2022-03-30 a la(s) 12 50 31" src="https://user-images.githubusercontent.com/6267487/160935988-07608638-08eb-4469-89ee-47f5e12db914.png">



### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
