### PR TITLE
fix: wrong carrier info with deprecated method

### DIFF
--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -128,6 +128,8 @@
             NSString *(*getMobileNetworkCode)(id, SEL) = (NSString *(*)(id, SEL))[carrierMap[key] methodForSelector:mobileNetworkCode];
             if (getMobileNetworkCode && getMobileNetworkCode(carrierMap[key], mobileNetworkCode) != nil){
                 carrier = carrierMap[key];
+                // exit early as we found a carrier here
+                break;
             }
         }
     } else {

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -110,8 +110,9 @@
     if (!CTTelephonyNetworkInfo) {
         return _carrier;
     }
-
-    networkInfo = [[CTTelephonyNetworkInfo alloc] init];
+    if (networkInfo == nil) {
+        networkInfo = [[CTTelephonyNetworkInfo alloc] init];
+    }
     id carrier = nil;
     SEL carrierName = NSSelectorFromString(@"carrierName");
 

--- a/Tests/DeviceInfoTests.m
+++ b/Tests/DeviceInfoTests.m
@@ -70,10 +70,12 @@
 }
 
 - (void)testModel {
-#if !TARGET_OS_OSX
-    XCTAssertEqualObjects(@"Simulator", _deviceInfo.model);
-#else
+#if TARGET_OS_OSX && TARGET_CPU_X86_64
     XCTAssertTrue([_deviceInfo.model containsString:@"Mac"]);
+#elif TARGET_CPU_ARM64
+    XCTAssertTrue([_deviceInfo.model containsString:@"arm64"]);
+#else
+    XCTAssertEqualObjects(@"Simulator", _deviceInfo.model);
 #endif
 }
 
@@ -99,6 +101,10 @@
     XCTAssertNotNil(b);
     XCTAssertNotEqual(a, b);
     XCTAssertNotEqual(a, b);
+}
+
+- (void)testCarrier {
+    XCTAssertEqualObjects(_deviceInfo.carrier, @"Unknown");
 }
 
 @end


### PR DESCRIPTION
### Summary

<!-- What does the PR do? -->
This PR addresses the wrong carrier information issue reported in https://github.com/amplitude/Amplitude-iOS/issues/399:
- introduce the condition for checking `iOS 12` and use the corresponding method for retrieving carrier info
- tested in an iPhone 13 mini device (one sim only)
- choose to get the updated carrier information always instead of monitoring the notification event

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
Yes
* Does your PR have a breaking change?:  <!-- Yes or no -->
No