### PR TITLE
revert: "Compile with code coverage enabled (#398)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,7 @@ let package = Package(
             ],
             path: "Sources",
             resources: [.process("Resources/ComodoRsaDomainValidationCA.der")],
-            publicHeadersPath: "Amplitude/Public",
-            linkerSettings: [.unsafeFlags(["-fprofile-instr-generate"])]
-        )
+            publicHeadersPath: "Amplitude/Public"),
     ]
 )
 


### PR DESCRIPTION
This reverts commit 55ee555c68c4c8e36d1166b608447cab3aec6b4f.

<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR is to revert the https://github.com/amplitude/Amplitude-iOS/pull/398, for the recent issue: https://github.com/amplitude/Amplitude-iOS/issues/401.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
