### PR TITLE
fix: turn requiringSecureCoding on, adjust the available version

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -1771,7 +1771,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (id)unarchive:(NSData *)data error:(NSError **)error {
-    if (@available(iOS 12, tvOS 11.0, macOS 10.13, watchOS 4.0, *)) {
+    if (@available(iOS 11, tvOS 11.0, macOS 10.13, watchOS 4.0, *)) {
         return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDictionary class] fromData:data error:error];
     } else {
 #pragma clang diagnostic push
@@ -1787,9 +1787,9 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 }
 
 - (BOOL)archive:(id)obj toFile:(NSString *)path {
-    if (@available(tvOS 11.0, iOS 12, macOS 10.13, watchOS 4.0, *)) {
+    if (@available(tvOS 11.0, iOS 11, macOS 10.13, watchOS 4.0, *)) {
         NSError *archiveError = nil;
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:&archiveError];
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:YES error:&archiveError];
         if (archiveError != nil) {
             AMPLITUDE_ERROR(@"ERROR: Unable to archive object %@: %@", obj, archiveError);
             return NO;


### PR DESCRIPTION
### Summary
- fix: turn requiringSecureCoding on, adjust the available version

Noticed that we already switch to the recommended methods:
- `NSKeyedArchiver archiveRootObject` => `NSKeyedArchiver archivedDataWithRootObject`
  - https://developer.apple.com/documentation/foundation/nskeyedarchiver/1410621-archiverootobject?language=objc
  - https://developer.apple.com/documentation/foundation/nskeyedarchiver/2962880-archiveddatawithrootobject 
- `NSKeyedUnarchiver unarchiveTopLevelObjectWithData` => `NSKeyedUnarchiver unarchivedObjectOfClass`
  - https://developer.apple.com/documentation/foundation/nskeyedunarchiver/1574811-unarchivetoplevelobjectwithdata
  - https://developer.apple.com/documentation/foundation/nskeyedunarchiver/2962884-unarchivedobjectofclass

Enable the `requiringSecureCoding` as https://developer.apple.com/documentation/foundation/nskeyedarchiver/2962880-archiveddatawithrootobject recommended. Cannot find any usage of `decodeObjectForKey` or `NSCoder` or `NSCoding` in existing code base.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
