### PR TITLE
feat: add ingestion_metadata field

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -175,6 +175,17 @@
 		3EF6090327267C9800133703 /* AMPMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EF6090127267C9800133703 /* AMPMiddleware.m */; };
 		3EF6090427267C9800133703 /* AMPMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EF6090127267C9800133703 /* AMPMiddleware.m */; };
 		3EF6090527267C9800133703 /* AMPMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EF6090127267C9800133703 /* AMPMiddleware.m */; };
+		582516E228C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 582516E128C048D600ECAD0D /* AMPIngestionMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		582516E328C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 582516E128C048D600ECAD0D /* AMPIngestionMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		582516E428C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 582516E128C048D600ECAD0D /* AMPIngestionMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		582516E528C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 582516E128C048D600ECAD0D /* AMPIngestionMetadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		582516E728C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516E628C048E700ECAD0D /* AMPIngestionMetadata.m */; };
+		582516E828C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516E628C048E700ECAD0D /* AMPIngestionMetadata.m */; };
+		582516E928C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516E628C048E700ECAD0D /* AMPIngestionMetadata.m */; };
+		582516EA28C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516E628C048E700ECAD0D /* AMPIngestionMetadata.m */; };
+		582516F028C075D100ECAD0D /* IngestionMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516EB28C075C300ECAD0D /* IngestionMetadataTests.m */; };
+		582516F128C075D200ECAD0D /* IngestionMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516EB28C075C300ECAD0D /* IngestionMetadataTests.m */; };
+		582516F228C075D300ECAD0D /* IngestionMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 582516EB28C075C300ECAD0D /* IngestionMetadataTests.m */; };
 		58E4B1BC287F62C3007AC408 /* AmazonRootCA1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 58E4B1BB287F62C3007AC408 /* AmazonRootCA1.cer */; };
 		58E4B1BD287F62C3007AC408 /* AmazonRootCA1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 58E4B1BB287F62C3007AC408 /* AmazonRootCA1.cer */; };
 		58E4B1BE287F62C3007AC408 /* AmazonRootCA1.cer in Resources */ = {isa = PBXBuildFile; fileRef = 58E4B1BB287F62C3007AC408 /* AmazonRootCA1.cer */; };
@@ -332,6 +343,9 @@
 		3EF6090127267C9800133703 /* AMPMiddleware.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMPMiddleware.m; sourceTree = "<group>"; };
 		3F7002FB71B21CB2ABA065F1 /* Pods-shared-Amplitude_macOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-Amplitude_macOSTests.debug.xcconfig"; path = "Target Support Files/Pods-shared-Amplitude_macOSTests/Pods-shared-Amplitude_macOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4D8EA610D8DF8BD11DB40E7A /* Pods-shared-Amplitude_tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-Amplitude_tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-shared-Amplitude_tvOSTests/Pods-shared-Amplitude_tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		582516E128C048D600ECAD0D /* AMPIngestionMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPIngestionMetadata.h; sourceTree = "<group>"; };
+		582516E628C048E700ECAD0D /* AMPIngestionMetadata.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMPIngestionMetadata.m; sourceTree = "<group>"; };
+		582516EB28C075C300ECAD0D /* IngestionMetadataTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IngestionMetadataTests.m; sourceTree = "<group>"; };
 		58E4B1BB287F62C3007AC408 /* AmazonRootCA1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = AmazonRootCA1.cer; sourceTree = "<group>"; };
 		6C55E7B2C7CB09D0EDC07910 /* Pods-shared-Amplitude_iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-Amplitude_iOSTests.release.xcconfig"; path = "Target Support Files/Pods-shared-Amplitude_iOSTests/Pods-shared-Amplitude_iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		70CE71E7AEFA4FE3E4F565AD /* Pods-shared-Amplitude_iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-shared-Amplitude_iOSTests.debug.xcconfig"; path = "Target Support Files/Pods-shared-Amplitude_iOSTests/Pods-shared-Amplitude_iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -487,6 +501,7 @@
 				3EF608E92726244300133703 /* AMPMiddlewareRunner.h */,
 				3EF608EE2726256800133703 /* AMPMiddlewareRunner.m */,
 				3EF6090127267C9800133703 /* AMPMiddleware.m */,
+				582516E628C048E700ECAD0D /* AMPIngestionMetadata.m */,
 			);
 			path = Amplitude;
 			sourceTree = "<group>";
@@ -527,6 +542,7 @@
 				3EF608DC27211AC000133703 /* ServerZoneUtilTests.m */,
 				3EF608E027211F8A00133703 /* ConfigManagerTests.m */,
 				3EF608FD272666E300133703 /* MiddlewareRunnerTests.m */,
+				582516EB28C075C300ECAD0D /* IngestionMetadataTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -548,6 +564,7 @@
 				1279F8E925244D78003DCE07 /* AMPTrackingOptions.h */,
 				3EF608C82720E74D00133703 /* AMPServerZone.h */,
 				3EF608E42724BFB700133703 /* AMPMiddleware.h */,
+				582516E128C048D600ECAD0D /* AMPIngestionMetadata.h */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -626,6 +643,7 @@
 				1279F92025244E8E003DCE07 /* AMPDatabaseHelper.h in Headers */,
 				1279F91725244E8E003DCE07 /* AMPConfigManager.h in Headers */,
 				1279F91625244E8E003DCE07 /* AMPUtils.h in Headers */,
+				582516E328C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -654,6 +672,7 @@
 				1279F90225244E8D003DCE07 /* AMPDatabaseHelper.h in Headers */,
 				1279F8F925244E8D003DCE07 /* AMPConfigManager.h in Headers */,
 				1279F8F825244E8D003DCE07 /* AMPUtils.h in Headers */,
+				582516E228C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -682,6 +701,7 @@
 				1279F93E25244E8F003DCE07 /* AMPDatabaseHelper.h in Headers */,
 				1279F93525244E8F003DCE07 /* AMPConfigManager.h in Headers */,
 				1279F93425244E8F003DCE07 /* AMPUtils.h in Headers */,
+				582516E428C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -710,6 +730,7 @@
 				759E93A725FBF44500BF7C3D /* AMPDatabaseHelper.h in Headers */,
 				759E93A525FBF44500BF7C3D /* AMPConfigManager.h in Headers */,
 				759E93B125FBF44500BF7C3D /* AMPUtils.h in Headers */,
+				582516E528C048D600ECAD0D /* AMPIngestionMetadata.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1054,6 +1075,7 @@
 			files = (
 				759E941125FBFE7800BF7C3D /* AMPBackgroundNotifier.m in Sources */,
 				1279FA6F2525949D003DCE07 /* ISPCertificatePinning.m in Sources */,
+				582516E828C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */,
 				3EF608F02726256800133703 /* AMPMiddlewareRunner.m in Sources */,
 				1279F91A25244E8E003DCE07 /* AMPUtils.m in Sources */,
 				3EF6090327267C9800133703 /* AMPMiddleware.m in Sources */,
@@ -1092,6 +1114,7 @@
 				3EF608E227211F8A00133703 /* ConfigManagerTests.m in Sources */,
 				12C973C2241244F000E9CDDB /* TrackingOptionsTest.m in Sources */,
 				3EF608DE27211AC000133703 /* ServerZoneUtilTests.m in Sources */,
+				582516F128C075D200ECAD0D /* IngestionMetadataTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1101,6 +1124,7 @@
 			files = (
 				759E941925FBFE7900BF7C3D /* AMPBackgroundNotifier.m in Sources */,
 				1279F8FE25244E8D003DCE07 /* AMPRevenue.m in Sources */,
+				582516E728C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */,
 				1279F90825244E8D003DCE07 /* AMPDatabaseHelper.m in Sources */,
 				3EF608D82720F64500133703 /* AMPServerZoneUtil.m in Sources */,
 				3E2411EC26F9A46500793829 /* AMPPlan.m in Sources */,
@@ -1139,6 +1163,7 @@
 				3EF608E127211F8A00133703 /* ConfigManagerTests.m in Sources */,
 				12C973BF241244EF00E9CDDB /* TrackingOptionsTest.m in Sources */,
 				3EF608DD27211AC000133703 /* ServerZoneUtilTests.m in Sources */,
+				582516F028C075D100ECAD0D /* IngestionMetadataTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1148,6 +1173,7 @@
 			files = (
 				759E940925FBFE7700BF7C3D /* AMPBackgroundNotifier.m in Sources */,
 				1279FA702525949D003DCE07 /* ISPCertificatePinning.m in Sources */,
+				582516E928C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */,
 				3EF608F12726256800133703 /* AMPMiddlewareRunner.m in Sources */,
 				1279F93825244E8F003DCE07 /* AMPUtils.m in Sources */,
 				3EF6090427267C9800133703 /* AMPMiddleware.m in Sources */,
@@ -1177,6 +1203,7 @@
 				12C973B3241244BF00E9CDDB /* AMPDatabaseHelperTests.m in Sources */,
 				58E4B1C2287F6FD7007AC408 /* SSLPinningTests.m in Sources */,
 				12C973AB241244AF00E9CDDB /* Amplitude+Test.m in Sources */,
+				582516F228C075D300ECAD0D /* IngestionMetadataTests.m in Sources */,
 				12C973B4241244BF00E9CDDB /* RevenueTests.m in Sources */,
 				3EF608E327211F8A00133703 /* ConfigManagerTests.m in Sources */,
 				12C973C7241244F100E9CDDB /* BaseTestCase.m in Sources */,
@@ -1194,6 +1221,7 @@
 			files = (
 				759E93DD25FBF6F700BF7C3D /* AMPBackgroundNotifier.m in Sources */,
 				759E939025FBF3DC00BF7C3D /* AMPConfigManager.m in Sources */,
+				582516EA28C048E700ECAD0D /* AMPIngestionMetadata.m in Sources */,
 				3EF608F22726256800133703 /* AMPMiddlewareRunner.m in Sources */,
 				759E939125FBF3DC00BF7C3D /* AMPConstants.m in Sources */,
 				759E939225FBF3DC00BF7C3D /* AMPDatabaseHelper.m in Sources */,

--- a/Framework/AmplitudeFramework.h
+++ b/Framework/AmplitudeFramework.h
@@ -5,6 +5,7 @@
 #import <Amplitude/AMPTrackingOptions.h>
 #import <Amplitude/Amplitude+SSLPinning.h>
 #import <Amplitude/AMPPlan.h>
+#import <Amplitude/AMPIngestionMetadata.h>
 #import <Amplitude/AMPMiddleware.h>
 #import <Amplitude/AMPServerZone.h>
 

--- a/Sources/Amplitude/AMPConstants.h
+++ b/Sources/Amplitude/AMPConstants.h
@@ -92,3 +92,7 @@ extern NSString *const AMP_PLAN_BRANCH;
 extern NSString *const AMP_PLAN_SOURCE;
 extern NSString *const AMP_PLAN_VERSION;
 extern NSString *const AMP_PLAN_VERSION_ID;
+
+// Ingestion Metadata
+extern NSString *const AMP_INGESTION_METADATA_SOURCE_NAME;
+extern NSString *const AMP_INGESTION_METADATA_SOURCE_VERSION;

--- a/Sources/Amplitude/AMPConstants.m
+++ b/Sources/Amplitude/AMPConstants.m
@@ -113,3 +113,6 @@ NSString *const AMP_PLAN_BRANCH = @"branch";
 NSString *const AMP_PLAN_SOURCE = @"source";
 NSString *const AMP_PLAN_VERSION = @"version";
 NSString *const AMP_PLAN_VERSION_ID = @"versionId";
+
+NSString *const AMP_INGESTION_METADATA_SOURCE_NAME = @"source_name";
+NSString *const AMP_INGESTION_METADATA_SOURCE_VERSION = @"source_version";

--- a/Sources/Amplitude/AMPIngestionMetadata.m
+++ b/Sources/Amplitude/AMPIngestionMetadata.m
@@ -1,0 +1,76 @@
+//
+//  AMPIngestionMetadata.m
+//  Copyright (c) 2022 Amplitude Inc. (https://amplitude.com/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#ifndef AMPLITUDE_LOG
+#if AMPLITUDE_DEBUG
+#   define AMPLITUDE_LOG(fmt, ...) NSLog(fmt, ##__VA_ARGS__)
+#else
+#   define AMPLITUDE_LOG(...)
+#endif
+#endif
+
+#import "AMPIngestionMetadata.h"
+#import "AMPConstants.h"
+#import "AMPUtils.h"
+
+@implementation AMPIngestionMetadata
+
+/*
+ * Create an AMPIngestionMetadata object
+ */
++ (instancetype)ingestionMetadata {
+    return [[self alloc] init];
+}
+
+- (AMPIngestionMetadata *)setSourceName:(NSString *)sourceName {
+    if ([AMPUtils isEmptyString:sourceName]) {
+        AMPLITUDE_LOG(@"Invalid empty sourceName");
+        return self;
+    }
+
+    _sourceName = sourceName;
+    return self;
+}
+
+- (AMPIngestionMetadata *)setSourceVersion:(NSString *)sourceVersion {
+    if ([AMPUtils isEmptyString:sourceVersion]) {
+        AMPLITUDE_LOG(@"Invalid empty sourceVersion");
+        return self;
+    }
+
+    _sourceVersion = sourceVersion;
+    return self;
+}
+
+- (NSDictionary *)toNSDictionary {
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+    if (_sourceName) {
+        [dict setValue:_sourceName forKey:AMP_INGESTION_METADATA_SOURCE_NAME];
+    }
+    if (_sourceVersion) {
+        [dict setValue:_sourceVersion forKey:AMP_INGESTION_METADATA_SOURCE_VERSION];
+    }
+    return dict;
+}
+
+@end

--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -59,6 +59,7 @@
 #import "AMPRevenue.h"
 #import "AMPTrackingOptions.h"
 #import "AMPPlan.h"
+#import "AMPIngestionMetadata.h"
 #import "AMPServerZone.h"
 #import "AMPServerZoneUtil.h"
 #import "AMPMiddleware.h"
@@ -140,6 +141,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     NSString *_serverUrl;
     NSString *_token;
     AMPPlan *_plan;
+    AMPIngestionMetadata *_ingestionMetadata;
     AMPServerZone _serverZone;
     AMPMiddlewareRunner *_middlewareRunner;
 }
@@ -716,6 +718,10 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     
     if (_plan) {
         [event setValue:[_plan toNSDictionary] forKey:@"plan"];
+    }
+
+    if (_ingestionMetadata) {
+        [event setValue:[_ingestionMetadata toNSDictionary] forKey:@"ingestion_metadata"];
     }
 
     NSMutableDictionary *apiProperties = [event valueForKey:@"api_properties"];
@@ -1492,6 +1498,10 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
 - (void)setPlan:(AMPPlan *)plan {
     _plan = plan;
+}
+
+- (void)setIngestionMetadata:(AMPIngestionMetadata *)ingestionMetadata {
+    _ingestionMetadata = ingestionMetadata;
 }
 
 - (void)setServerZone:(AMPServerZone)serverZone {

--- a/Sources/Amplitude/Public/AMPIngestionMetadata.h
+++ b/Sources/Amplitude/Public/AMPIngestionMetadata.h
@@ -1,0 +1,39 @@
+//
+//  AMPIngestionMetadata.h
+//  Copyright (c) 2022 Amplitude Inc. (https://amplitude.com/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+#import <Foundation/Foundation.h>
+
+@interface AMPIngestionMetadata : NSObject
+
+@property (nonatomic, strong, readonly) NSString *sourceName;
+
+@property (nonatomic, strong, readonly) NSString *sourceVersion;
+
++ (instancetype)ingestionMetadata;
+
+- (AMPIngestionMetadata *)setSourceName:(NSString *)sourceName;
+
+- (AMPIngestionMetadata *)setSourceVersion:(NSString *)sourceVersion;
+
+- (NSDictionary *)toNSDictionary;
+
+@end

--- a/Sources/Amplitude/Public/Amplitude.h
+++ b/Sources/Amplitude/Public/Amplitude.h
@@ -26,6 +26,7 @@
 #import "AMPRevenue.h"
 #import "AMPTrackingOptions.h"
 #import "AMPPlan.h"
+#import "AMPIngestionMetadata.h"
 #import "AMPServerZone.h"
 #import "AMPMiddleware.h"
 
@@ -655,6 +656,8 @@ typedef void (^AMPInitCompletionBlock)(void);
 - (void)setBearerToken:(NSString *)token;
 
 - (void)setPlan:(AMPPlan *)plan;
+
+- (void)setIngestionMetadata:(AMPIngestionMetadata *)ingestionMetadata;
 
 /**
  * Set Amplitude Server Zone, switch to zone related configuration, including dynamic configuration and server url.

--- a/Tests/AmplitudeTests.m
+++ b/Tests/AmplitudeTests.m
@@ -16,6 +16,7 @@
 #import "AMPUtils.h"
 #import "AMPTrackingOptions.h"
 #import "AMPPlan.h"
+#import "AMPIngestionMetadata.h"
 #import "AMPServerZone.h"
 
 @interface Amplitude (Tests)
@@ -1107,6 +1108,23 @@
     XCTAssertEqualObjects(source, planValue[@"source"]);
     XCTAssertEqualObjects(version, planValue[@"version"]);
     XCTAssertEqualObjects(versionId, planValue[@"versionId"]);
+}
+
+- (void)testSetIngestionMetadata {
+    Amplitude *client = [Amplitude instanceWithName:@"ingestion_metadata"];
+    [client initializeApiKey:@"ingestion_metadata"];
+    NSString *sourceName = @"ampli";
+    NSString *sourceVersion = @"2.0.0";
+
+    AMPIngestionMetadata *ingestionMetadata = [[[AMPIngestionMetadata ingestionMetadata] setSourceName:sourceName] setSourceVersion:sourceVersion];
+    [client setIngestionMetadata:ingestionMetadata];
+    [client logEvent:@"test"];
+    [client flushQueue];
+    NSDictionary *event = [client getLastEventFromInstanceName:@"ingestion_metadata"];
+
+    NSDictionary *ingestionMetadataValue = event[@"ingestion_metadata"];
+    XCTAssertEqualObjects(sourceName, ingestionMetadataValue[@"source_name"]);
+    XCTAssertEqualObjects(sourceVersion, ingestionMetadataValue[@"source_version"]);
 }
 
 - (void)testSetServerZone {

--- a/Tests/IngestionMetadataTests.m
+++ b/Tests/IngestionMetadataTests.m
@@ -1,0 +1,66 @@
+//
+//  IngestionMetadataTests.m
+//  Amplitude
+//
+//  Created by Marvin Liu on 8/31/22.
+//  Copyright © 2022 Amplitude. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AMPIngestionMetadata.h"
+#import "AMPConstants.h"
+
+@interface IngestionMetadataTests : XCTestCase
+
+@end
+
+@implementation IngestionMetadataTests { }
+
+- (void)testSetSourceName {
+    AMPIngestionMetadata *ingestionMetadata = [AMPIngestionMetadata ingestionMetadata];
+    XCTAssertNil(ingestionMetadata.sourceName);
+
+    NSString *sourceName = @"ampli";
+    [ingestionMetadata setSourceName:sourceName];
+    XCTAssertEqualObjects(ingestionMetadata.sourceName, sourceName);
+
+    // test that ignore empty inputs
+    [ingestionMetadata setSourceName:nil];
+    XCTAssertEqualObjects(ingestionMetadata.sourceName, sourceName);
+    [ingestionMetadata setSourceName:@""];
+    XCTAssertEqualObjects(ingestionMetadata.sourceName, sourceName);
+
+    NSDictionary *dict = [ingestionMetadata toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"source_name"], sourceName);
+}
+
+- (void)testSetSourceVersion {
+    AMPIngestionMetadata *ingestionMetadata = [AMPIngestionMetadata ingestionMetadata];
+    XCTAssertNil(ingestionMetadata.sourceVersion);
+
+    NSString *sourceVersion = @"2.0.0";
+    [ingestionMetadata setSourceVersion:sourceVersion];
+    XCTAssertEqualObjects(ingestionMetadata.sourceVersion, sourceVersion);
+
+    // test that ignore empty inputs
+    [ingestionMetadata setSourceVersion:nil];
+    XCTAssertEqualObjects(ingestionMetadata.sourceVersion, sourceVersion);
+    [ingestionMetadata setSourceVersion:@""];
+    XCTAssertEqualObjects(ingestionMetadata.sourceVersion, sourceVersion);
+
+    NSDictionary *dict = [ingestionMetadata toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"source_version"], sourceVersion);
+}
+
+- (void)testToNSDictionary {
+    NSString *sourceName = @"ampli";
+    NSString *sourceVersion = @"2.0.0";
+
+    AMPIngestionMetadata *ingestionMetadata = [[[AMPIngestionMetadata ingestionMetadata] setSourceName:sourceName] setSourceVersion:sourceVersion];
+
+    NSDictionary *dict = [ingestionMetadata toNSDictionary];
+    XCTAssertEqualObjects([dict objectForKey:@"source_name"], sourceName);
+    XCTAssertEqualObjects([dict objectForKey:@"source_version"], sourceVersion);
+}
+
+@end


### PR DESCRIPTION
### Summary
- feat: add ingestion_metadata field

Add this option in the configuration, which can be used in the library wrapper/code generation/dynamic loading cases, for setting the `ingestion_metadata` information.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
