### PR TITLE
feat: add workaround to manually check in foreground

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -465,33 +465,39 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
             }
         }];
 
-        // Normally _inForeground is set by the enterForeground callback, but initializeWithApiKey will be called after the app's enterForeground
-        // notification is already triggered, so we need to manually check and set it now.
-        // UIApplication methods are only allowed on the main thread so need to dispatch this synchronously to the main thread.
-        void (^checkInForeground)(void) = ^{
-        #if !TARGET_OS_OSX && !TARGET_OS_WATCH
-            UIApplication *app = [AMPUtils getSharedApplication];
-            if (app != nil) {
-                UIApplicationState state = app.applicationState;
-                if (state != UIApplicationStateBackground) {
-                    [self runOnBackgroundQueue:^{
-        #endif
-                        // The earliest time to fetch dynamic config
-                        [self refreshDynamicConfig];
-                        
-                        NSNumber *now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
-                        [self startOrContinueSessionNSNumber:now];
-                        self->_inForeground = YES;
-        #if !TARGET_OS_OSX && !TARGET_OS_WATCH
-                    }];
-
-                }
-            }
-        #endif
-        };
-        [self runSynchronouslyOnMainQueue:checkInForeground];
-        _initialized = YES;
+        if (!self.deferCheckInForeground) {
+            [self checkInForeground];
+        }
     }
+}
+
+- (void) checkInForeground {
+    // Normally _inForeground is set by the enterForeground callback, but initializeWithApiKey will be called after the app's enterForeground
+    // notification is already triggered, so we need to manually check and set it now.
+    // UIApplication methods are only allowed on the main thread so need to dispatch this synchronously to the main thread.
+    void (^checkInForeground)(void) = ^{
+    #if !TARGET_OS_OSX && !TARGET_OS_WATCH
+        UIApplication *app = [AMPUtils getSharedApplication];
+        if (app != nil) {
+            UIApplicationState state = app.applicationState;
+            if (state != UIApplicationStateBackground) {
+                [self runOnBackgroundQueue:^{
+    #endif
+                    // The earliest time to fetch dynamic config
+                    [self refreshDynamicConfig];
+
+                    NSNumber *now = [NSNumber numberWithLongLong:[[self currentTime] timeIntervalSince1970] * 1000];
+                    [self startOrContinueSessionNSNumber:now];
+                    self->_inForeground = YES;
+    #if !TARGET_OS_OSX && !TARGET_OS_WATCH
+                }];
+
+            }
+        }
+    #endif
+    };
+    [self runSynchronouslyOnMainQueue:checkInForeground];
+    _initialized = YES;
 }
 
 /**

--- a/Sources/Amplitude/Public/Amplitude.h
+++ b/Sources/Amplitude/Public/Amplitude.h
@@ -196,6 +196,12 @@ typedef void (^AMPInitCompletionBlock)(void);
  */
 @property (nonatomic, strong, nullable) AMPInitCompletionBlock initCompletionBlock;
 
+/**
+ * Defer the forground check in initializeApiKey.
+ * checkInForeground need to be manually called in order to get the right config and session info if deferCheckInForeground = true has been set.
+ */
+@property (nonatomic, assign) BOOL deferCheckInForeground;
+
 #pragma mark - Methods
 
 /**-----------------------------------------------------------------------------
@@ -251,6 +257,10 @@ typedef void (^AMPInitCompletionBlock)(void);
 */
 - (void)initializeApiKey:(NSString *)apiKey userId:(nullable NSString *)userId;
 
+/**
+* Manually check in and set the forground related settings including dynamic config and sesstion. Need to be called manually when onEnterForeground if  deferCheckInForeground = true.
+*/
+- (void)checkInForeground;
 
 /**-----------------------------------------------------------------------------
  * @name Logging Events

--- a/Tests/AmplitudeTests.m
+++ b/Tests/AmplitudeTests.m
@@ -21,6 +21,8 @@
 
 @interface Amplitude (Tests)
 
+@property (nonatomic, assign) bool initialized;
+
 - (NSDictionary*)mergeEventsAndIdentifys:(NSMutableArray*)events identifys:(NSMutableArray*)identifys numEvents:(long) numEvents;
 - (id)truncate:(id) obj;
 - (long long)getNextSequenceNumber;
@@ -1199,5 +1201,22 @@
     XCTAssertEqualObjects([identifys[0] objectForKey:@"user_properties"], userProperties);
 }
 
+-(void)testNoDeferCheckInForeground {
+    NSString *instanceName = @"noDeferCheckInForegroundInstance";
+    Amplitude *client = [Amplitude instanceWithName:instanceName];
+    [client initializeApiKey:@"api-key"];
+    XCTAssertEqual(client.initialized, YES);
+}
+
+-(void)testDeferCheckInForeground {
+    NSString *instanceName = @"DeferCheckInForegroundInstance";
+    Amplitude *client = [Amplitude instanceWithName:instanceName];
+    [client setDeferCheckInForeground:YES];
+    [client initializeApiKey:@"api-key"];
+    XCTAssertEqual(client.initialized, NO);
+
+    [client checkInForeground];
+    XCTAssertEqual(client.initialized, YES);
+}
 
 @end


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
This pr is related to this[ jira ticket](https://amplitude.atlassian.net/jira/software/c/projects/AMP/boards/197?modal=detail&selectedIssue=AMP-59346&assignee=60185777b4982300703075c9).

Originally, the initialization function will block the main thread caused by the `checkInForeground` callback function.
This pr is for providing a workaround to allow customers manually call the checkInForeground on OnEnterForeGround. 

<!-- What does the PR do? -->

### Checklist

* [ x ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
