### PR TITLE
fix: AMP-69475 transfer intercepted Identify's on user identity change

### DIFF
--- a/Sources/Amplitude/AMPEventUtils.h
+++ b/Sources/Amplitude/AMPEventUtils.h
@@ -28,6 +28,8 @@
 
 @interface AMPEventUtils : NSObject
 
++ (NSString *_Nullable)getUserId:(NSDictionary *_Nonnull)event;
++ (NSString *_Nullable)getDeviceId:(NSDictionary *_Nonnull)event;
 + (long long)getEventId:(NSDictionary *_Nonnull)event;
 + (NSString *_Nullable)getEventType:(NSDictionary *_Nonnull)event;
 + (NSMutableDictionary *_Nullable)getGroups:(NSDictionary *_Nonnull)event;

--- a/Sources/Amplitude/AMPEventUtils.m
+++ b/Sources/Amplitude/AMPEventUtils.m
@@ -48,6 +48,14 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
     return nil;
 }
 
++ (NSString *_Nullable)getUserId:(NSDictionary *_Nonnull)event {
+    return [event valueForKey:@"user_id"];
+}
+
++ (NSString *_Nullable)getDeviceId:(NSDictionary *_Nonnull)event {
+    return [event valueForKey:@"device_id"];
+}
+
 + (long long)getEventId:(NSDictionary *_Nonnull)event {
     return [[event objectForKey:@"event_id"] longValue];
 }


### PR DESCRIPTION
### Summary

* Update Identify intercept logic to transfer intercepted events on user identity change (user id, device id)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
