### PR TITLE
fix: transfer intercepted Identify's on user identity change

### DIFF
--- a/Sources/Amplitude/AMPIdentifyInterceptor.m
+++ b/Sources/Amplitude/AMPIdentifyInterceptor.m
@@ -252,6 +252,7 @@ BOOL _disabled;
     }
 }
 
+// Transfers all intercepted Identify's as a single Identify to (non-intercepted) Identify storage
 - (void)transferInterceptedIdentify {
     NSMutableDictionary *interceptedIdentify = [self getCombinedInterceptedIdentify];
     if (interceptedIdentify != nil) {


### PR DESCRIPTION
### Summary

Version didn't bump on last release for some reason. 

This PR has `fix: ` in both the PR title and the commit message. Hoping this should bump to `8.15.1`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
