### PR TITLE
fix: fix os version

### DIFF
--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -78,11 +78,6 @@
         _osVersion = [[WKInterfaceDevice currentDevice] systemVersion];
         #elif !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
         _osVersion = [[UIDevice currentDevice] systemVersion];
-        /*        
-        #elif TARGET_OS_IPHONE
-         _osVersion = [[UIDevice currentDevice] systemVersion];
-        #else
-        */
         #else
         NSOperatingSystemVersion systemVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
         _osVersion = [NSString stringWithFormat:@"%ld.%ld.%ld",

--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -76,8 +76,13 @@
     if (!_osVersion) {
         #if TARGET_OS_WATCH
         _osVersion = [[WKInterfaceDevice currentDevice] systemVersion];
-        #elif !TARGET_OS_OSX
+        #elif !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
         _osVersion = [[UIDevice currentDevice] systemVersion];
+        /*        
+        #elif TARGET_OS_IPHONE
+         _osVersion = [[UIDevice currentDevice] systemVersion];
+        #else
+        */
         #else
         NSOperatingSystemVersion systemVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
         _osVersion = [NSString stringWithFormat:@"%ld.%ld.%ld",


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
This is the fix for https://amplitude.atlassian.net/browse/DXOC-526?focusedCommentId=169089
TARGET_OS_MACCATALYST is the iPad app that runs on MacOS. Based on the previous logic, the os version will be the iOS version. It makes sense to use the mac version for the os version for this case. Otherwise, the os will be `macos 15.0` which is not a valid macOS version.  Check here for how the current os version looks like https://analytics.amplitude.com/linearity/chart/6db6un2/edit/us3pssm.

With these changes, the TARGET_OS_MACCATALYST will fall into checking the mac os version instead.
<img width="841" alt="screenshot" src="https://user-images.githubusercontent.com/13028329/223597224-af85880e-8c7d-4b28-9cbe-147c6a304f3a.png">


<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
