### PR TITLE
fix: updated identify merging logic to ignore nil values

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-title-check:
     name: Check PR for semantic title
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: PR title is valid
         if: >

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-title-check:
     name: Check PR for semantic title
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: PR title is valid
         if: >

--- a/Sources/Amplitude/AMPIdentifyInterceptor.m
+++ b/Sources/Amplitude/AMPIdentifyInterceptor.m
@@ -213,15 +213,8 @@ BOOL _disabled;
         NSString *operation = _interceptOps[opIndex];
         NSMutableDictionary *mergedOperationKVPs = [NSMutableDictionary dictionary];
 
-        NSMutableDictionary *operationKVPs = userPropertyOperations[operation];
-        if (operationKVPs != nil) {
-            [mergedOperationKVPs addEntriesFromDictionary:[AMPUtils removeNilValues:operationKVPs]];
-        }
-
-        NSMutableDictionary *operationKVPsToMerge = userPropertyOperationsToMerge[operation];
-        if (operationKVPsToMerge != nil) {
-            [mergedOperationKVPs addEntriesFromDictionary:[AMPUtils removeNilValues:operationKVPsToMerge]];
-        }
+        [AMPUtils addNonNilEntriesToDictionary:mergedOperationKVPs fromDictionary:userPropertyOperations[operation]];
+        [AMPUtils addNonNilEntriesToDictionary:mergedOperationKVPs fromDictionary:userPropertyOperationsToMerge[operation]];
 
         if (mergedOperationKVPs.count > 0) {
             [mergedUserProperties setValue:mergedOperationKVPs forKey:operation];
@@ -234,9 +227,7 @@ BOOL _disabled;
 - (NSMutableDictionary *_Nonnull)mergeUserProperties:(NSMutableDictionary *_Nonnull) userProperties withUserProperties:(NSMutableDictionary *_Nonnull) userPropertiesToMerge {
     NSMutableDictionary *mergedUserProperties = [userProperties mutableCopy] ?: [NSMutableDictionary dictionary];
 
-    if (userPropertiesToMerge != nil) {
-        [mergedUserProperties addEntriesFromDictionary:[AMPUtils removeNilValues:userPropertiesToMerge]];
-    }
+    [AMPUtils addNonNilEntriesToDictionary:mergedUserProperties fromDictionary:userPropertiesToMerge];
 
     return mergedUserProperties;
 }

--- a/Sources/Amplitude/AMPIdentifyInterceptor.m
+++ b/Sources/Amplitude/AMPIdentifyInterceptor.m
@@ -34,6 +34,7 @@
 
 #import <Foundation/Foundation.h>
 #import "AMPConstants.h"
+#import "AMPUtils.h"
 #import "AMPEventUtils.h"
 #import "AMPIdentifyInterceptor.h"
 #import "AMPDatabaseHelper.h"
@@ -214,12 +215,12 @@ BOOL _disabled;
 
         NSMutableDictionary *operationKVPs = userPropertyOperations[operation];
         if (operationKVPs != nil) {
-            [mergedOperationKVPs addEntriesFromDictionary:operationKVPs];
+            [mergedOperationKVPs addEntriesFromDictionary:[AMPUtils removeNilValues:operationKVPs]];
         }
 
         NSMutableDictionary *operationKVPsToMerge = userPropertyOperationsToMerge[operation];
         if (operationKVPsToMerge != nil) {
-            [mergedOperationKVPs addEntriesFromDictionary:operationKVPsToMerge];
+            [mergedOperationKVPs addEntriesFromDictionary:[AMPUtils removeNilValues:operationKVPsToMerge]];
         }
 
         if (mergedOperationKVPs.count > 0) {
@@ -230,11 +231,11 @@ BOOL _disabled;
     return mergedUserProperties;
 }
 
-- (NSMutableDictionary *_Nonnull)mergeUserProperties:(NSMutableDictionary *_Nonnull) userPropertiess withUserProperties:(NSMutableDictionary *_Nonnull) userPropertiesToMerge {
-    NSMutableDictionary *mergedUserProperties = [userPropertiess mutableCopy] ?: [NSMutableDictionary dictionary];
+- (NSMutableDictionary *_Nonnull)mergeUserProperties:(NSMutableDictionary *_Nonnull) userProperties withUserProperties:(NSMutableDictionary *_Nonnull) userPropertiesToMerge {
+    NSMutableDictionary *mergedUserProperties = [userProperties mutableCopy] ?: [NSMutableDictionary dictionary];
 
     if (userPropertiesToMerge != nil) {
-        [mergedUserProperties addEntriesFromDictionary:userPropertiesToMerge];
+        [mergedUserProperties addEntriesFromDictionary:[AMPUtils removeNilValues:userPropertiesToMerge]];
     }
 
     return mergedUserProperties;

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -30,6 +30,7 @@
 
 + (NSString *)generateUUID;
 + (id)makeJSONSerializable:(id)obj;
++ (NSMutableDictionary *)removeNilValues:(NSDictionary *)dict;
 + (BOOL)isEmptyString:(NSString *)str;
 + (NSDictionary *)validateGroups:(NSDictionary *)obj;
 + (NSString *)platformDataDirectory;

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -30,7 +30,7 @@
 
 + (NSString *)generateUUID;
 + (id)makeJSONSerializable:(id)obj;
-+ (NSMutableDictionary *)removeNilValues:(NSDictionary *)dict;
++ (NSMutableDictionary *)addNonNilEntriesToDictionary:(NSMutableDictionary *)destination fromDictionary:(NSDictionary *)source;
 + (BOOL)isEmptyString:(NSString *)str;
 + (NSDictionary *)validateGroups:(NSDictionary *)obj;
 + (NSString *)platformDataDirectory;

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -96,6 +96,13 @@
     return str;
 }
 
++ (NSMutableDictionary *)removeNilValues:(NSDictionary *)dict {
+    NSMutableDictionary *d = [dict mutableCopy];
+    NSArray *keysForNullValues = [d allKeysForObject:[NSNull null]];
+    [d removeObjectsForKeys:keysForNullValues];
+    return d;
+}
+
 + (BOOL)isEmptyString:(NSString *)str {
     return str == nil || [str isKindOfClass:[NSNull class]] || [str length] == 0;
 }

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -96,14 +96,16 @@
     return str;
 }
 
-+ (NSMutableDictionary *)removeNilValues:(NSDictionary *)dict {
-    NSMutableDictionary *pruned = [NSMutableDictionary dictionary];
-    for (NSString * key in [dict allKeys]) {
-        if (![[dict objectForKey:key] isKindOfClass:[NSNull class]]) {
-            [pruned setObject:[dict objectForKey:key] forKey:key];
++ (NSMutableDictionary *)addNonNilEntriesToDictionary:(NSMutableDictionary *)destination fromDictionary:(NSDictionary *)source {
+    if (source != nil) {
+        for (NSString * key in [source allKeys]) {
+            if (![[source objectForKey:key] isKindOfClass:[NSNull class]]) {
+                [destination setObject:[source objectForKey:key] forKey:key];
+            }
         }
     }
-    return pruned;
+    
+    return destination;
 }
 
 + (BOOL)isEmptyString:(NSString *)str {

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -97,10 +97,13 @@
 }
 
 + (NSMutableDictionary *)removeNilValues:(NSDictionary *)dict {
-    NSMutableDictionary *d = [dict mutableCopy];
-    NSArray *keysForNullValues = [d allKeysForObject:[NSNull null]];
-    [d removeObjectsForKeys:keysForNullValues];
-    return d;
+    NSMutableDictionary *pruned = [NSMutableDictionary dictionary];
+    for (NSString * key in [dict allKeys]) {
+        if (![[dict objectForKey:key] isKindOfClass:[NSNull class]]) {
+            [pruned setObject:[dict objectForKey:key] forKey:key];
+        }
+    }
+    return pruned;
 }
 
 + (BOOL)isEmptyString:(NSString *)str {


### PR DESCRIPTION
### Summary

* https://amplitude.atlassian.net/browse/DXOC-747
* updated identify merging logic to ignore nil values to prevent clearing existing user properties

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
