### PR TITLE
fix: update identify collapsing logic to send actions on separate identify event

### DIFF
--- a/Sources/Amplitude/AMPIdentifyInterceptor.m
+++ b/Sources/Amplitude/AMPIdentifyInterceptor.m
@@ -46,7 +46,6 @@ NSSet *_Nonnull _interceptOpsSet;
 BOOL _transferScheduled;
 NSOperationQueue *_Nonnull _backgroundQueue;
 AMPDatabaseHelper *_Nonnull _dbHelper;
-long _lastIdentifyInterceptorId;
 BOOL _hasIdentity;
 NSString *_Nullable _userId;
 NSString *_Nullable _deviceId;
@@ -59,7 +58,6 @@ BOOL _disabled;
     if(self = [super init]) {
         _dbHelper = dbHelper;
         _backgroundQueue = backgroundQueue;
-        _lastIdentifyInterceptorId = -1;
         _interceptedUploadPeriodSeconds = kAMPIdentifyUploadPeriodSeconds;
         _transferScheduled = NO;
         _disabled = NO;
@@ -148,61 +146,15 @@ BOOL _disabled;
             // Clear all pending intercepted Identify's
             [_dbHelper removeInterceptedIdentifys:[_dbHelper getLastSequenceNumber]];
        } else {
-            // This is an "active" Identify, merge intercepted user properties
-            event = [event mutableCopy];
-            [self mergeInterceptedUserProperties:event];
+            [self transferInterceptedIdentify];
        }
     } else if ([eventType isEqualToString:GROUP_IDENTIFY_EVENT]) {
         // Group identify = no op
     } else {
-        // Normal event, merge intercepted user properties
-        event = [event mutableCopy];
-        [self mergeInterceptedUserProperties:event];
+        [self transferInterceptedIdentify];
     }
 
     return event;
-}
-
-/**
- * Merged all pending intercepted user properties to the given @event
- * Clears intercepted Idenitfy's from DB
- */
-- (void)mergeInterceptedUserProperties:(NSMutableDictionary *_Nonnull) event {
-    BOOL flattenOperations = [[AMPEventUtils getEventType:event] isEqualToString:IDENTIFY_EVENT] == NO;
-
-    NSMutableDictionary *mergedUserProperties = [[AMPEventUtils getUserProperties:event] mutableCopy];
-
-    // Load any intercepted Identify events from DB
-    NSMutableDictionary *interceptedIdentify = [self getCombinedInterceptedIdentify];
-    if (interceptedIdentify != nil) {
-        NSMutableDictionary * interceptedUserProperties = [AMPEventUtils getUserProperties:interceptedIdentify];
-        if (flattenOperations) {
-            interceptedUserProperties = interceptedUserProperties[AMP_OP_SET];
-            mergedUserProperties = [self mergeUserProperties:mergedUserProperties
-                                          withUserProperties:interceptedUserProperties];
-        } else {
-            mergedUserProperties = [self mergeUserPropertyOperations:mergedUserProperties
-                                        withUserPropertiesOperations:interceptedUserProperties];
-        }
-    }
-
-    // Get the event's userProperties and apply them over the intercepted values
-    NSMutableDictionary *eventUserProperties = [AMPEventUtils getUserProperties:event];
-    if (eventUserProperties != nil) {
-        if (flattenOperations) {
-            mergedUserProperties = [self mergeUserProperties:mergedUserProperties
-                                          withUserProperties:eventUserProperties];
-        } else {
-            mergedUserProperties = [self mergeUserPropertyOperations:mergedUserProperties
-                                        withUserPropertiesOperations:eventUserProperties];
-        }
-    }
-
-    // Apply merged user properties to the
-    [AMPEventUtils setUserProperties:event userProperties:mergedUserProperties];
-
-    // remove intercepted identifies from db
-    [_dbHelper removeInterceptedIdentifys:[_dbHelper getLastSequenceNumber]];
 }
 
 - (NSMutableDictionary *_Nonnull)mergeUserPropertyOperations:(NSMutableDictionary *_Nonnull) userPropertyOperations withUserPropertiesOperations:(NSMutableDictionary *_Nonnull) userPropertyOperationsToMerge {
@@ -220,14 +172,6 @@ BOOL _disabled;
             [mergedUserProperties setValue:mergedOperationKVPs forKey:operation];
         }
     }
-
-    return mergedUserProperties;
-}
-
-- (NSMutableDictionary *_Nonnull)mergeUserProperties:(NSMutableDictionary *_Nonnull) userProperties withUserProperties:(NSMutableDictionary *_Nonnull) userPropertiesToMerge {
-    NSMutableDictionary *mergedUserProperties = [userProperties mutableCopy] ?: [NSMutableDictionary dictionary];
-
-    [AMPUtils addNonNilEntriesToDictionary:mergedUserProperties fromDictionary:userPropertiesToMerge];
 
     return mergedUserProperties;
 }

--- a/Tests/Amplitude+Test.h
+++ b/Tests/Amplitude+Test.h
@@ -28,6 +28,7 @@
 - (NSDictionary *)getLastIdentify;
 - (NSDictionary *)getLastInterceptedIdentify;
 - (NSDictionary *)getEvent:(NSInteger) fromEnd;
+- (NSDictionary *)getIdentify:(NSInteger) fromEnd;
 - (NSUInteger)queuedEventCount;
 - (void)enterForeground;
 - (void)enterBackground;

--- a/Tests/Amplitude+Test.m
+++ b/Tests/Amplitude+Test.m
@@ -50,6 +50,11 @@
     return [identifys lastObject];
 }
 
+- (NSDictionary *)getIdentify:(NSInteger) fromEnd {
+    NSArray *identifys = [[AMPDatabaseHelper getDatabaseHelper] getIdentifys:-1 limit:-1];
+    return [identifys objectAtIndex:[identifys count] - fromEnd - 1];
+}
+
 - (NSDictionary *)getLastInterceptedIdentify {
     NSArray *interceptedIdentifys = [[AMPDatabaseHelper getDatabaseHelper] getInterceptedIdentifys:-1 limit:-1];
     return [interceptedIdentifys lastObject];

--- a/Tests/AmplitudeTests.m
+++ b/Tests/AmplitudeTests.m
@@ -1345,21 +1345,24 @@
     XCTAssertEqual([dbHelper getInterceptedIdentifyCount], 1);
 
     // log active identify
-    [self.amplitude identify:[[AMPIdentify identify] add:@"add-key-1" value:[NSNumber numberWithInt:1]]];
+    [self.amplitude identify:[[AMPIdentify identify] add:@"add-key-1" value:@1]];
     [self.amplitude flushQueue];
 
     XCTAssertEqual([dbHelper getInterceptedIdentifyCount], 0);
-    XCTAssertEqual([dbHelper getTotalEventCount], 1);
-    XCTAssertEqual([dbHelper getIdentifyCount], 1);
+    XCTAssertEqual([dbHelper getTotalEventCount], 2);
+    XCTAssertEqual([dbHelper getIdentifyCount], 2);
 
     NSDictionary *lastIdentify = [self.amplitude getLastIdentify];
     NSMutableDictionary *lastIdentifyUserProperties = [AMPEventUtils getUserProperties:lastIdentify];
     NSArray *lastIdentifyUserPropertiesOperations = [lastIdentifyUserProperties allKeys];
-
-    XCTAssertEqual(lastIdentifyUserPropertiesOperations.count, 2);
-    XCTAssertTrue([lastIdentifyUserProperties[AMP_OP_SET][@"set-key-1"] isEqualToString:@"set-value-1"]);
+    XCTAssertEqual(lastIdentifyUserPropertiesOperations.count, 1);
     XCTAssertTrue([lastIdentifyUserProperties[AMP_OP_ADD][@"add-key-1"] isEqualToNumber:@1]);
 
+    NSDictionary *interceptedIdentify = [self.amplitude getIdentify:1];
+    NSMutableDictionary *interceptedIdentifyUserProperties = [AMPEventUtils getUserProperties:interceptedIdentify];
+    NSArray *interceptedIdentifyUserPropertiesOperations = [interceptedIdentifyUserProperties allKeys];
+    XCTAssertEqual(interceptedIdentifyUserPropertiesOperations.count, 1);
+    XCTAssertTrue([interceptedIdentifyUserProperties[AMP_OP_SET][@"set-key-1"] isEqualToString:@"set-value-1"]);
 
     // log intercept identify 2
     [self.amplitude identify:[[AMPIdentify identify] set:@"set-key-2" value:@"set-value-2"]];
@@ -1372,14 +1375,20 @@
 
     XCTAssertEqual([dbHelper getInterceptedIdentifyCount], 0);
     XCTAssertEqual([dbHelper getEventCount], 1);
-    XCTAssertEqual([dbHelper getTotalEventCount], 2);
+    XCTAssertEqual([dbHelper getTotalEventCount], 4);
+    XCTAssertEqual([dbHelper getIdentifyCount], 3);
 
     NSDictionary *lastEvent = [self.amplitude getLastEvent];
     NSMutableDictionary *lastEventUserProperties = [AMPEventUtils getUserProperties:lastEvent];
+    XCTAssertNotNil(lastEventUserProperties);
     NSArray *lastEventUserPropertiesOperations = [lastEventUserProperties allKeys];
+    XCTAssertEqual(lastEventUserPropertiesOperations.count, 0);
 
-    XCTAssertEqual(lastEventUserPropertiesOperations.count, 1);
-    XCTAssertTrue([lastEventUserProperties[@"set-key-2"] isEqualToString:@"set-value-2"]);
+    interceptedIdentify = [self.amplitude getLastIdentify];
+    interceptedIdentifyUserProperties = [AMPEventUtils getUserProperties:interceptedIdentify];
+    interceptedIdentifyUserPropertiesOperations = [interceptedIdentifyUserProperties allKeys];
+    XCTAssertEqual(interceptedIdentifyUserPropertiesOperations.count, 1);
+    XCTAssertTrue([interceptedIdentifyUserProperties[AMP_OP_SET][@"set-key-2"] isEqualToString:@"set-value-2"]);
 
     // log intercept identify 3
     // this value should be cleared after "unset"
@@ -1392,8 +1401,8 @@
     [self.amplitude flushQueue];
 
     XCTAssertEqual([dbHelper getInterceptedIdentifyCount], 0);
-    XCTAssertEqual([dbHelper getIdentifyCount], 2);
-    XCTAssertEqual([dbHelper getTotalEventCount], 3);
+    XCTAssertEqual([dbHelper getIdentifyCount], 4);
+    XCTAssertEqual([dbHelper getTotalEventCount], 5);
 
     NSDictionary *unsetIdentify = [self.amplitude getLastIdentify];
     NSMutableDictionary *unsetIdentifyUserProperties = [AMPEventUtils getUserProperties:unsetIdentify];
@@ -1456,16 +1465,21 @@
     [self.amplitude flushQueue];
 
     XCTAssertEqual([dbHelper getInterceptedIdentifyCount], 0);
-    XCTAssertEqual([dbHelper getTotalEventCount], 1);
-    XCTAssertEqual([dbHelper getIdentifyCount], 1);
+    XCTAssertEqual([dbHelper getTotalEventCount], 2);
+    XCTAssertEqual([dbHelper getIdentifyCount], 2);
 
     NSDictionary *lastIdentify = [self.amplitude getLastIdentify];
     NSMutableDictionary *lastIdentifyUserProperties = [AMPEventUtils getUserProperties:lastIdentify];
     NSArray *lastIdentifyUserPropertiesOperations = [lastIdentifyUserProperties allKeys];
-
     XCTAssertEqual(lastIdentifyUserPropertiesOperations.count, 1);
-    XCTAssertTrue([lastIdentifyUserProperties[AMP_OP_SET][@"set-key-1"] isEqualToString:@"set-value-1"]);
+    XCTAssertTrue([lastIdentifyUserProperties[AMP_OP_SET][@"group_type"] isEqualToString:@"group_value"]);
     XCTAssertTrue([lastIdentify[@"groups"][@"group_type"] isEqualToString:@"group_value"]);
+
+    NSDictionary *interceptedIdentify = [self.amplitude getIdentify:1];
+    NSMutableDictionary *interceptedIdentifyUserProperties = [AMPEventUtils getUserProperties:interceptedIdentify];
+    NSArray *interceptedIdentifyUserPropertiesOperations = [interceptedIdentifyUserProperties allKeys];
+    XCTAssertEqual(interceptedIdentifyUserPropertiesOperations.count, 1);
+    XCTAssertTrue([interceptedIdentifyUserProperties[AMP_OP_SET][@"set-key-1"] isEqualToString:@"set-value-1"]);
 }
 
 - (void)testInterceptIdentifysAreSentOnUserIdChange {

--- a/Tests/SessionTests.m
+++ b/Tests/SessionTests.m
@@ -50,6 +50,8 @@
     [mockAmplitude initializeApiKey:apiKey];
     [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     [mockAmplitude verify];
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
 }
@@ -64,6 +66,8 @@
     [mockAmplitude initializeApiKey:apiKey];
     [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
 }
 
@@ -77,6 +81,8 @@
     [mockAmplitude initializeApiKey:apiKey userId:nil];
     [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
     XCTAssertEqual([mockAmplitude sessionId], 1000000);
 
@@ -87,12 +93,15 @@
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date)] currentTime];
     [mockAmplitude enterBackground]; // simulate app entering background
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude sessionId], 1000000);
 
     NSDate *date2 = [NSDate dateWithTimeIntervalSince1970:1000 + (self.amplitude.minTimeBetweenSessionsMillis / 1000)];
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date2)] currentTime];
     [mockAmplitude enterForeground]; // simulate app entering foreground
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 0);
     XCTAssertEqual([mockAmplitude sessionId], 1000000 + self.amplitude.minTimeBetweenSessionsMillis);
@@ -103,6 +112,7 @@
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date3)] currentTime];
     [mockAmplitude logEvent:@"continue_session"];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
 
     XCTAssertEqual([[mockAmplitude lastEventTime] longLongValue], 1001000 + self.amplitude.minTimeBetweenSessionsMillis);
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
@@ -118,6 +128,7 @@
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date5)] currentTime];
     [mockAmplitude enterForeground]; // simulate app entering foreground
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
     XCTAssertEqual([mockAmplitude sessionId], 1000000 + self.amplitude.minTimeBetweenSessionsMillis);
@@ -128,6 +139,8 @@
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date6)] currentTime];
     [mockAmplitude logEvent:@"No Session" withEventProperties:nil outOfSession:NO];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssert([[mockAmplitude getLastEvent][@"session_id"]
                isEqualToNumber:[NSNumber numberWithLongLong:1000000 + self.amplitude.minTimeBetweenSessionsMillis]]);
 
@@ -136,6 +149,8 @@
     // An out of session event should have session_id = -1
     [mockAmplitude logEvent:@"No Session" withEventProperties:nil outOfSession:YES];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssert([[mockAmplitude getLastEvent][@"session_id"]
                isEqualToNumber:[NSNumber numberWithLongLong:-1]]);
 
@@ -160,6 +175,8 @@
 #endif
 
     [self.amplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([self.amplitude queuedEventCount], 0);
 }
 
@@ -172,6 +189,7 @@
     [mockAmplitude initializeApiKey:apiKey userId:nil];
     [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
     XCTAssertEqual([[mockAmplitude getLastEvent][@"session_id"] longLongValue], 1000000);
@@ -186,6 +204,8 @@
     [((Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date2)]) currentTime];
     [mockAmplitude enterForeground]; // simulate app entering foreground
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude queuedEventCount], 3);
 
     long long expectedSessionId = 1000000 + self.amplitude.minTimeBetweenSessionsMillis;
@@ -207,6 +227,8 @@
     AMPIdentify *identify = [[AMPIdentify identify] set:@"key" value:@"value"];
     [mockAmplitude identify:identify outOfSession:NO];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude queuedEventCount], 5); // triggers session events
 
     // test out of session identify with app in background
@@ -214,6 +236,8 @@
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date4)] currentTime];
     [mockAmplitude identify:identify outOfSession:YES];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude queuedEventCount], 5); // does not trigger session events
 }
 
@@ -226,6 +250,7 @@
     [mockAmplitude initializeApiKey:apiKey userId:nil];
     [mockAmplitude flushQueueWithQueue:[mockAmplitude initializerQueue]];
     [mockAmplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
 
     XCTAssertEqual([mockAmplitude queuedEventCount], 1);
     XCTAssertEqual([[mockAmplitude getLastEvent][@"session_id"] longLongValue], 21474836470000);
@@ -240,6 +265,8 @@
     [(Amplitude *)[[mockAmplitude expect] andReturnValue:OCMOCK_VALUE(date2)] currentTime];
     [mockAmplitude enterForeground]; // simulate app entering foreground
     [self.amplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([mockAmplitude queuedEventCount], 3);
 
     XCTAssertEqual([mockAmplitude sessionId], 214748364700000);
@@ -262,6 +289,8 @@
     [self.amplitude initializeApiKey:apiKey userId:nil];
 
     [self.amplitude flushQueue];
+    [NSThread sleepForTimeInterval:0.2];
+
     XCTAssertEqual([dbHelper getEventCount], 2);
     NSArray *events = [dbHelper getEvents:-1 limit:2];
     XCTAssertEqualObjects(events[0][@"event_type"], kAMPSessionEndEvent);


### PR DESCRIPTION
### Summary

Update identify collapsing logic to send actions on separate identify event.

Added small delays to session tests to make them stable in CI.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
