### PR TITLE
chore: try to fix CI build - remove caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,17 +45,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-      - name: Cache Bundle Gems and Cocoapods
-        id: cache-gems-pods
-        uses: actions/cache@v2
-        with:
-          path: |
-            Pods
-            vendor/bundle
-          key: ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}-pods-${{ hashFiles('**/Podfile.lock') }}
-
       - name: Install Cocoapods
-        if: steps.cache-gems-pods.outputs.cache-hit != 'true'
         run: |
           gem install bundler
           bundle config path vendor/bundle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,17 +25,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-      - name: Cache Bundle Gems and Cocoapods
-        id: cache-gems-pods
-        uses: actions/cache@v2
-        with:
-          path: |
-            Pods
-            vendor/bundle
-          key: ${{ runner.os }}-ruby-${{ matrix.ruby-version }}-gems-${{ hashFiles('**/Gemfile.lock') }}-pods-${{ hashFiles('**/Podfile.lock') }}
-
       - name: Install Cocoapods
-        if: steps.cache-gems-pods.outputs.cache-hit != 'true'
         run: |
           gem install bundler
           bundle config path vendor/bundle


### PR DESCRIPTION
### Summary

Try to fix CI tests - cache key didn't include XCode version and the cache was restored for previous XCode version. Something like:
```
Cache restored from key: macOS-ruby-2.7.x-gems-553f4ac067309ad8e96575e2d4ca9118b6741a35581c85d274c6a1e785458fa7-pods-b0491051b34f7da0cb4b36524405c751b8411c6cdb1c5930ee2f02329afbd096
```
Warning in logs:
```
The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
```

I tried to add XCode version to cache keys - cache should be updated but it doesn't help (first run - okm second run - the same error).

Now I remove caching at all.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
