### PR TITLE
fix: appledoc in CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           cd appledoc/
           sudo sh install-appledoc.sh
           cd ../
-          rm -rf appledoc/
+          sudo rm -rf appledoc/
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}


### PR DESCRIPTION
### Summary

* Fix [error deleting `appledocs` folder](https://github.com/amplitude/Amplitude-iOS/actions/runs/5126540057/jobs/9221162366) after install

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
