### PR TITLE
fix: fix for when macos sandbox disabled

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -138,6 +138,9 @@
 		3E2411F526F9A4E100793829 /* PlanTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2411F026F9A4C600793829 /* PlanTests.m */; };
 		3E2411F626F9A4E200793829 /* PlanTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2411F026F9A4C600793829 /* PlanTests.m */; };
 		3E2411F726F9A4E400793829 /* PlanTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2411F026F9A4C600793829 /* PlanTests.m */; };
+		3E6FCF262B71B11900A31DC3 /* AMPUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E6FCF252B71B11900A31DC3 /* AMPUtilsTests.m */; };
+		3E6FCF272B71B11900A31DC3 /* AMPUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E6FCF252B71B11900A31DC3 /* AMPUtilsTests.m */; };
+		3E6FCF282B71B11900A31DC3 /* AMPUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E6FCF252B71B11900A31DC3 /* AMPUtilsTests.m */; };
 		3EF608C92720E74D00133703 /* AMPServerZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EF608C82720E74D00133703 /* AMPServerZone.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3EF608CA2720E74D00133703 /* AMPServerZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EF608C82720E74D00133703 /* AMPServerZone.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3EF608CB2720E74D00133703 /* AMPServerZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EF608C82720E74D00133703 /* AMPServerZone.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -372,6 +375,7 @@
 		3E2411E626F9A40100793829 /* AMPPlan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AMPPlan.h; sourceTree = "<group>"; };
 		3E2411EB26F9A46500793829 /* AMPPlan.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPPlan.m; sourceTree = "<group>"; };
 		3E2411F026F9A4C600793829 /* PlanTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlanTests.m; sourceTree = "<group>"; };
+		3E6FCF252B71B11900A31DC3 /* AMPUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AMPUtilsTests.m; sourceTree = "<group>"; };
 		3EF608C82720E74D00133703 /* AMPServerZone.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPServerZone.h; sourceTree = "<group>"; };
 		3EF608D22720F52400133703 /* AMPServerZoneUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AMPServerZoneUtil.h; sourceTree = "<group>"; };
 		3EF608D72720F64500133703 /* AMPServerZoneUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AMPServerZoneUtil.m; sourceTree = "<group>"; };
@@ -580,6 +584,7 @@
 		12C9730F24108DFF00E9CDDB /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				3E6FCF252B71B11900A31DC3 /* AMPUtilsTests.m */,
 				D00A34EB2991EBE300BA484F /* IdentifyInterceptorTests.m */,
 				3E2411F026F9A4C600793829 /* PlanTests.m */,
 				12C9731824108DFF00E9CDDB /* BaseTestCase.h */,
@@ -1201,6 +1206,7 @@
 				3EF608DE27211AC000133703 /* ServerZoneUtilTests.m in Sources */,
 				58D45C332A4CDC7C00A090A3 /* ScreenViewTests.m in Sources */,
 				582516F128C075D200ECAD0D /* IngestionMetadataTests.m in Sources */,
+				3E6FCF272B71B11900A31DC3 /* AMPUtilsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1257,6 +1263,7 @@
 				3EF608DD27211AC000133703 /* ServerZoneUtilTests.m in Sources */,
 				58D45C322A4CDC7C00A090A3 /* ScreenViewTests.m in Sources */,
 				582516F028C075D100ECAD0D /* IngestionMetadataTests.m in Sources */,
+				3E6FCF262B71B11900A31DC3 /* AMPUtilsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1293,6 +1300,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3E6FCF282B71B11900A31DC3 /* AMPUtilsTests.m in Sources */,
 				12C973B7241244C700E9CDDB /* SetupTests.m in Sources */,
 				3E2411F726F9A4E400793829 /* PlanTests.m in Sources */,
 				12C973C6241244F100E9CDDB /* IdentifyTests.m in Sources */,

--- a/Sources/Amplitude/AMPDatabaseHelper.m
+++ b/Sources/Amplitude/AMPDatabaseHelper.m
@@ -120,7 +120,9 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
     if ((self = [super init])) {
         NSString *databaseDirectory = [AMPUtils platformDataDirectory];
-        NSString *databasePath = [databaseDirectory stringByAppendingPathComponent:@"com.amplitude.database"];
+        NSString *appPathWithBundleIdenitfier = [NSString stringWithFormat:@"com.amplitude.database.%@", [[NSBundle mainBundle] bundleIdentifier]];
+        NSString *appPath = [AMPUtils isSandboxEnabled] ? @"com.amplitude.database" : appPathWithBundleIdenitfier;
+        NSString *databasePath = [databaseDirectory stringByAppendingPathComponent:appPath];
         if (![instanceName isEqualToString:kAMPDefaultInstance]) {
             databasePath = [NSString stringWithFormat:@"%@_%@", databasePath, instanceName];
         }

--- a/Sources/Amplitude/AMPUtils.h
+++ b/Sources/Amplitude/AMPUtils.h
@@ -34,6 +34,8 @@
 + (BOOL)isEmptyString:(NSString *)str;
 + (NSDictionary *)validateGroups:(NSDictionary *)obj;
 + (NSString *)platformDataDirectory;
++ (NSDictionary<NSString *, NSString *> *)getEnvironment;
++ (BOOL)isSandboxEnabled;
 
 #if !TARGET_OS_OSX && !TARGET_OS_WATCH
 + (UIApplication *)getSharedApplication;

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -220,4 +220,21 @@
 
 #endif
 
+// Helper function to get the environment variables
++ (NSDictionary<NSString *, NSString *> *)getEnvironment {
+    return [[NSProcessInfo processInfo] environment];
+}
+
+// Method to check if sandbox is enabled
++ (BOOL)isSandboxEnabled {
+    #if TARGET_OS_OSX
+        // Check if macOS app has "App Sandbox" enabled
+        NSDictionary<NSString *, NSString *> *environment = [self getEnvironment];
+        return environment[@"APP_SANDBOX_CONTAINER_ID"] != nil;
+    #else
+        // Other platforms (iOS, tvOS, watchOS) are sandboxed by default
+        return YES;
+    #endif
+}
+
 @end

--- a/Tests/AMPUtilsTests.m
+++ b/Tests/AMPUtilsTests.m
@@ -1,0 +1,29 @@
+//
+//  AMPUtilsTests.m
+//  Amplitude
+//
+//  Created by Qingzhuo Zhen on 2/5/24.
+//  Copyright © 2024 Amplitude. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "AMPUtils.h"
+
+@interface AMPUtilTests : XCTestCase
+
+@end
+
+@implementation AMPUtilTests {
+    
+}
+
+- (void) testIsSandboxEnabled {
+    BOOL isSandboxEnabled = [AMPUtils isSandboxEnabled];
+    #if TARGET_OS_OSX
+        XCTAssertEqual(isSandboxEnabled, NO);
+    #else
+        XCTAssertEqual(isSandboxEnabled, YES);
+    #endif
+}
+
+@end

--- a/Tests/AMPUtilsTests.m
+++ b/Tests/AMPUtilsTests.m
@@ -13,9 +13,18 @@
 
 @end
 
-@implementation AMPUtilTests {
-    
+@interface FakeAMPUtils: AMPUtils
+@end
+
+@implementation FakeAMPUtils
+
++ (NSDictionary *)getEnvironment {
+    return @{@"APP_SANDBOX_CONTAINER_ID": @"test-container-id"};
 }
+
+@end
+
+@implementation AMPUtilTests {}
 
 - (void) testIsSandboxEnabled {
     BOOL isSandboxEnabled = [AMPUtils isSandboxEnabled];
@@ -25,5 +34,12 @@
         XCTAssertEqual(isSandboxEnabled, YES);
     #endif
 }
+
+#if TARGET_OS_OSX
+- (void) testIsSandboxEnabledWhenMacOSIsSandboxed {
+    BOOL isSandboxEnabled = [FakeAMPUtils isSandboxEnabled];
+    XCTAssertEqual(isSandboxEnabled, YES);
+}
+#endif
 
 @end


### PR DESCRIPTION
### Summary

- fix for app directory in macos when sandbox is not enabled for app.

When sandboxed, sample path:
/Users/{user}/Library/Containers/com.test.Test/Data/Library/com.amplitude.database
When not sandboxed, sample path:
/Users/{user}/Library/com.amplitude.database.com.test.Test


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Only affecting the special case for apps on macos without sandbox enabled.
