### PR TITLE
chore: update README to note deprecation and promote migration to Swift SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,20 @@
   <br />
 </p>
 
+[![Legacy SDK](https://img.shields.io/badge/state-legacy-yellow)](https://github.com/amplitude/Amplitude-Swift)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Amplitude)](https://cocoapods.org/pods/Amplitude)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat)](#contributors-)
+
+# Announcement 📣
+
+Amplitude is introducing a new [iOS Swift SDK](https://github.com/amplitude/Amplitude-Swift). This new SDK provides improved developer experience, helps users instrument data more seamlessly and provide more control over data being instrumented using custom plugins.
+
+To learn more about the new SDK, here are some useful links:
+
+* GitHub: https://github.com/amplitude/Amplitude-Swift
+* Documentation: https://www.docs.developers.amplitude.com/data/sdks/ios-swift/
+* Migration Guide: https://www.docs.developers.amplitude.com/data/sdks/ios-swift/migration/
 
 # Official Amplitude iOS SDK
 iOS/tvOS/macOS SDK for tracking events and revenue to [Amplitude](https://www.amplitude.com).


### PR DESCRIPTION
### Summary

* update README to note deprecation and promote migration to Swift SDK

<img width="887" alt="image" src="https://github.com/amplitude/Amplitude-iOS/assets/5790872/cf17b42d-d928-4372-9948-1b615130fa65">

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
