### PR TITLE
fix: Copy extra params to prevent deallocation

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -680,6 +680,7 @@ static NSString *const APP_BUILD = @"app_build";
     userProperties = [userProperties copy];
     groups = [groups copy];
     groupProperties = [groupProperties copy];
+    extra = [extra copy];
     BOOL inForeground = _inForeground;
 
     [self runOnBackgroundQueue:^{


### PR DESCRIPTION
### Summary

Copy extra properties to make sure it does not get deallocated before the middlewares run

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
