### PR TITLE
fix(PrivacyInfo) SPM/Cocoapods support for privacy manifest

### DIFF
--- a/Amplitude.podspec
+++ b/Amplitude.podspec
@@ -15,19 +15,19 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target  = '10.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.ios.resources          = 'Sources/Resources/*.{der}'
+  s.ios.resources          = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
 
   s.tvos.deployment_target = '9.0'
   s.tvos.source_files      = 'Sources/Amplitude/**/*.{h,m}'
-  s.tvos.resources         = 'Sources/Resources/*.{der}'
+  s.tvos.resources         = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
 
   s.osx.deployment_target  = '10.10'
   s.osx.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.osx.resources          = 'Sources/Resources/*.{der}'
+  s.osx.resources          = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
 
   s.watchos.deployment_target  = '3.0'
   s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.watchos.resources          = 'Sources/Resources/*.{der}'
+  s.watchos.resources          = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
   
   s.dependency 'AnalyticsConnector', '~> 1.0.0'
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
             path: "Sources",
             resources: [
                 .process("Resources"),
+                .copy("PrivacyInfo.xcprivacy")
             ],
             publicHeadersPath: "Amplitude/Public"),
     ]


### PR DESCRIPTION
### Summary

This PR adds exporting of the PrivacyInfo information added in version 8.18.0 for use via SPM and Cocoapods.

I have tested it with SPM and Cocoapods sample projects, and now it successfully fetches the information.

The process to add it in Cocoapods is the same as used by multiple projects. Ref. https://github.com/CocoaPods/CocoaPods/issues/10325#issuecomment-1718723762 and to add it in SPM, I have looked at other projects such as Revenuecat https://github.com/RevenueCat/purchases-ios/blob/main/Package.swift.

Issues Related:
https://github.com/amplitude/Amplitude-iOS/issues/482
https://github.com/amplitude/Amplitude-iOS/issues/470


Thanks for Amplitude!

> ### Checklist
* [x]  Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
