### PR TITLE
chore: delete tracking domain from privacy manifest

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -8,7 +8,7 @@
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
+			<true/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
@@ -40,13 +40,6 @@
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
-	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>https://api2.amplitude.com/</string>
-		<string>https://api.eu.amplitude.com/</string>
-		<string>https://regionconfig.amplitude.com/</string>
-		<string>https://regionconfig.eu.amplitude.com/</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Update "Product interaction" to "Linked to User"
- Delete tracking domains 

> If you set NSPrivacyTracking to true then you need to provide at least one internet domain in NSPrivacyTrackingDomains; otherwise, you can provide zero or more domains.

This PR is from https://github.com/amplitude/amplitude-dev-center/pull/276#discussion_r1550220212.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
