### PR TITLE
fix: specify resource_bundle vs resource for resources in cocoapods

### DIFF
--- a/Amplitude.podspec
+++ b/Amplitude.podspec
@@ -15,19 +15,19 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target  = '10.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.ios.resources          = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
+  s.ios.resource_bundle    = { 'Amplitude_Amplitude': ['Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'] }
 
   s.tvos.deployment_target = '9.0'
   s.tvos.source_files      = 'Sources/Amplitude/**/*.{h,m}'
-  s.tvos.resources         = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
+  s.tvos.resource_bundle    = { 'Amplitude_Amplitude': ['Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'] }
 
   s.osx.deployment_target  = '10.10'
   s.osx.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.osx.resources          = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
+  s.osx.resource_bundle    = { 'Amplitude_Amplitude': ['Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'] }
 
   s.watchos.deployment_target  = '3.0'
   s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,m}'
-  s.watchos.resources          = 'Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'
+  s.watchos.resource_bundle    = { 'Amplitude_Amplitude': ['Sources/Resources/*.{der}', 'Sources/PrivacyInfo.xcprivacy'] }
   
   s.dependency 'AnalyticsConnector', '~> 1.0.0'
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix for https://github.com/amplitude/Amplitude-iOS/pull/487#issuecomment-2043709593

Adopt `resource_bundle` syntax to prevent name resource name conflicts when statically linked in cocoapods (see https://guides.cocoapods.org/syntax/podspec.html#resource_bundles).

I've tested that the certificates are bundled correctly and a privacy report generates properly when linked statically and when linked as a framework (via `use_frameworks!` flag in the Podfile).

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
