### PR TITLE
fix: Prevent crashes in multithreaded environments with sqlite.

### DIFF
--- a/Sources/Amplitude/AMPDatabaseHelper.m
+++ b/Sources/Amplitude/AMPDatabaseHelper.m
@@ -81,6 +81,8 @@ static NSString *const GET_VALUE = @"SELECT %@, %@ FROM %@ WHERE %@ = ?;";
 
 static NSString *const SEQUENCE_NUMBER = @"sequence_number";
 
+static int const OPEN_DB_FLAGS = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
+
 + (AMPDatabaseHelper *)getDatabaseHelper {
     return [AMPDatabaseHelper getDatabaseHelper:nil];
 }
@@ -159,7 +161,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         __block BOOL success = YES;
 
         dispatch_sync(_queue, ^{
-            if (sqlite3_open([self->_databasePath UTF8String], &self->_database) != SQLITE_OK) {
+            if (sqlite3_open_v2(self->_databasePath.UTF8String, &self->_database, OPEN_DB_FLAGS, NULL) != SQLITE_OK) {
                 AMPLITUDE_LOG(@"Failed to open database");
                 sqlite3_close(self->_database);
                 success = NO;
@@ -195,7 +197,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         __block BOOL success = YES;
 
         dispatch_sync(_queue, ^{
-            if (sqlite3_open([self->_databasePath UTF8String], &self->_database) != SQLITE_OK) {
+            if (sqlite3_open_v2(self->_databasePath.UTF8String, &self->_database, OPEN_DB_FLAGS, NULL) != SQLITE_OK) {
                 AMPLITUDE_LOG(@"Failed to open database");
                 sqlite3_close(self->_database);
                 success = NO;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We've seen some reported crashes in sqlite internals coming from our SDK. I suspect this is a threading issue as most of the crashes occur on background threads and the customer is using multiple instances of Amplitude.

Our current threading strategy is to dispatch all db operations to a single queue, and to recreate a connection per operation. This _should_ work with the default multithread [threading strategy](https://www.sqlite.org/threadsafe.html), where sqlite is thread safe if connections aren't shared between threads.

But, dispatching to a single queue doesn't mean that we always run on the same thread, and we have no synchronization mechanism between instances of the SDK. This means that a single thread may run connections to two different databases, though none should simultaneously be open. 

A possible fix is to opt us in to a more strict treading mode for sqlite - the FULL_MUTEX mode linearizes calls between threads and enables full multithreaded access to sqlite objects. There is a tradeoff in performance, though this should be minimal.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
