### PR TITLE
fix: correct documentation for sessions default value

### DIFF
--- a/Sources/Amplitude/Public/AMPDefaultTrackingOptions.h
+++ b/Sources/Amplitude/Public/AMPDefaultTrackingOptions.h
@@ -29,7 +29,7 @@
 @interface AMPDefaultTrackingOptions : NSObject
 
 /**
- Enables/disables session tracking. Default to enabled.
+ Enables/disables session tracking. Default to disabled.
  */
 @property (nonatomic, assign) BOOL sessions;
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

sessions tracking is actually defaulted to disabled. (see https://github.com/amplitude/Amplitude-iOS/issues/510)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
