### PR TITLE
fix: prefix server zone constants

### DIFF
--- a/Sources/Amplitude/Public/AMPServerZone.h
+++ b/Sources/Amplitude/Public/AMPServerZone.h
@@ -33,7 +33,10 @@ typedef NS_ENUM(NSInteger, AMPServerZone);
 #ifndef AMPServerZone_h
 #define AMPServerZone_h
 typedef NS_ENUM(NSInteger, AMPServerZone) {
-    US,
-    EU
+    AMPServerZoneUS = 0,
+    AMPServerZoneEU = 1,
 };
+
+static const AMPServerZone US = AMPServerZoneUS;
+static const AMPServerZone EU = AMPServerZoneEU;
 #endif


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude iOS/tvOS/macOS SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Both AmplitudeCore and Amplitude-iOS contain the same ObjC enum, `AMPServerZone`.  This causes build errors when Session Replay and our legacy SDK are both imported within the same project.  Note that enums can simultaneously exist in both projects if both the ObjC definitions are exactly the same.

A few possible fixes:

1/ Make Amplitude-iOS import AmplitudeCore and import the enums from there. This is suboptimal as Amplitude-iOS is deprecated and we don't want to add a new dependency.
2/ Match enum cases from Amplitude-iOS to AmplitudeCore by adding EU and US. Then, we'd have the issue of unprefixed enum cases for ObjC in our supported SDKs.
3/ Match enum cases from AmplitudeCore to Amplitude-iOS, alias existing US/EU constants for backwards compatibility. This may be slightly breaking, though should be source compatible in most cases.

I've opted for 3/ as this seems the least disruptive.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-iOS/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
