### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@main
+    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@8dadabbe62161729e3aa83c0d664e106b748c8cc # @amplitude/plugin-session-replay-react-native@0.4.9
     with:
       label: "iOS"
       subcomponent: "dx_ios_sdk"

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@8dadabbe62161729e3aa83c0d664e106b748c8cc # @amplitude/plugin-session-replay-react-native@0.4.9
+    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@8dadabbe62161729e3aa83c0d664e106b748c8cc # main
     with:
       label: "iOS"
       subcomponent: "dx_ios_sdk"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-13
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: octokit/request-action@v2.1.9
+        uses: octokit/request-action@89697eb6635e52c6e1e5559f15b5c91ba5100cb0 # v2.1.9
         with:
           route: GET /repos/:repository/collaborators/${{ github.actor }}
           repository: ${{ github.repository }}
@@ -31,7 +31,7 @@ jobs:
         node-version: ["16.x"]
     steps:
       - name: Checkout Amplitude-iOS
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Xcode 14.2
         run: |
@@ -41,7 +41,7 @@ jobs:
         run: carthage bootstrap --use-xcframeworks
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -82,12 +82,12 @@ jobs:
         run: pod lib lint --verbose
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Checkout Amplitude-iOS gh-pages for building docs
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: "gh-pages"
           path: "Amplitude-iOS-gh-pages"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         ruby-version: ["2.7"]
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Xcode 16
         run: |
@@ -27,7 +27,7 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via automated scripts.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 2026-04-10.

For any questions, please ask in the Slack channel #help-security.
